### PR TITLE
Low Dissipation Roe Flux

### DIFF
--- a/src/numerical_flux/convective_numerical_flux.cpp
+++ b/src/numerical_flux/convective_numerical_flux.cpp
@@ -72,13 +72,135 @@ std::array<real, nstate> LaxFriedrichs<dim,nstate,real>
     return numerical_flux_dot_n;
 }
 
-template<int dim, int nstate, typename real>
-std::array<real, nstate> Roe<dim,nstate,real>
+template <int dim, int nstate, typename real>
+void RoePike<dim,nstate,real>
+::evaluate_entropy_fix (
+    const std::array<real, 3> &eig_L,
+    const std::array<real, 3> &eig_R,
+    std::array<real, 3> &eig_RoeAvg,
+    const real /*vel2_ravg*/,
+    const real /*sound_ravg*/) const
+{
+    // Harten's entropy fix
+    // -- See Blazek 2015, p.103-105
+    for(int e=0;e<3;e++) {
+        const real eps = std::max(abs(eig_RoeAvg[e] - eig_L[e]), abs(eig_R[e] - eig_RoeAvg[e]));
+        if(eig_RoeAvg[e] < eps) {
+            eig_RoeAvg[e] = 0.5*(eig_RoeAvg[e] * eig_RoeAvg[e]/eps + eps);
+        }
+    }
+}
+
+template <int dim, int nstate, typename real>
+void RoePike<dim,nstate,real>
+::evaluate_additional_modifications (
+    const std::array<real, nstate> &/*soln_int*/,
+    const std::array<real, nstate> &/*soln_ext*/,
+    const std::array<real, 3> &/*eig_L*/,
+    const std::array<real, 3> &/*eig_R*/,
+    real &/*dV_normal*/, 
+    dealii::Tensor<1,dim,real> &/*dV_tangent*/
+    ) const
+{
+    // No additional modifications for the Roe-Pike scheme
+}
+
+template <int dim, int nstate, typename real>
+void L2Roe<dim,nstate,real>
+::evaluate_shock_indicator (
+    const std::array<real, 3> &eig_L,
+    const std::array<real, 3> &eig_R,
+    int &ssw_LEFT,
+    int &ssw_RIGHT) const
+{
+    // Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
+    // -- See also p.74 of Osswald et al. (2016 L2Roe)
+    
+    ssw_LEFT=0; ssw_RIGHT=0; // initialize
+    
+    // ssw_L: i=L --> j=R
+    if((eig_L[0]>0.0 && eig_R[0]<0.0) || (eig_L[2]>0.0 && eig_R[2]<0.0)) {
+        ssw_LEFT = 1;
+    }
+    
+    // ssw_R: i=R --> j=L
+    if((eig_R[0]>0.0 && eig_L[0]<0.0) || (eig_R[2]>0.0 && eig_L[2]<0.0)) {
+        ssw_RIGHT = 1;
+    }
+}
+
+template <int dim, int nstate, typename real>
+void L2Roe<dim,nstate,real>
+::evaluate_entropy_fix (
+    const std::array<real, 3> &eig_L,
+    const std::array<real, 3> &eig_R,
+    std::array<real, 3> &eig_RoeAvg,
+    const real vel2_ravg,
+    const real sound_ravg) const
+{
+    // Van Leer et al. (1989 Sonic) entropy fix for acoustic waves
+    // -- p.74 of Osswald et al. (2016 L2Roe)
+    for(int e=0;e<3;e++) {
+        if(e!=1) {
+            // const real deig = std::max((eig_R[e]-eig_L[e]), 0.0);
+            const real deig = std::max(static_cast<real>(eig_R[e] - eig_L[e]), static_cast<real>(0.0));
+            if(eig_RoeAvg[e] < 2.0*deig) {
+                eig_RoeAvg[e] = 0.25*(eig_RoeAvg[e] * eig_RoeAvg[e]/deig) + deig;
+            }
+        }
+    }
+    
+    // Entropy fix of Liou (2000 Mass)
+    // -- p.74 of Osswald et al. (2016 L2Roe)
+    int ssw_L, ssw_R;
+    evaluate_shock_indicator(eig_L,eig_R,ssw_L,ssw_R);
+    if(ssw_L!=0 || ssw_R!=0) {
+        eig_RoeAvg[1] = std::max(sound_ravg, static_cast<real>(sqrt(vel2_ravg)));
+    }
+}
+
+template <int dim, int nstate, typename real>
+void L2Roe<dim,nstate,real>
+::evaluate_additional_modifications  (
+    const std::array<real, nstate> &soln_int,
+    const std::array<real, nstate> &soln_ext,
+    const std::array<real, 3> &eig_L,
+    const std::array<real, 3> &eig_R,
+    real &dV_normal, 
+    dealii::Tensor<1,dim,real> &dV_tangent) const
+{
+    const real mach_number_L = this->euler_physics->compute_mach_number(soln_int);
+    const real mach_number_R = this->euler_physics->compute_mach_number(soln_ext);
+
+    // Osswald's two modifications to Roe-Pike scheme --> L2Roe
+    // - Blending factor (variable 'z' in reference)
+    const real blending_factor = std::min(static_cast<real>(1.0), std::max(mach_number_L,mach_number_R));
+    // - Scale jump in (1) normal and (2) tangential velocities
+    int ssw_L, ssw_R;
+    evaluate_shock_indicator(eig_L,eig_R,ssw_L,ssw_R);
+    if(ssw_L==0 && ssw_R==0)
+    {
+        dV_normal *= blending_factor;
+        for (int d=0;d<dim;d++)
+        {
+            dV_tangent[d] *= blending_factor;
+        }
+    }
+}
+
+// Compute the flux equation
+template <int dim, int nstate, typename real>
+std::array<real, nstate> RoeBase<dim,nstate,real>
 ::evaluate_flux (
     const std::array<real, nstate> &soln_int,
     const std::array<real, nstate> &soln_ext,
     const dealii::Tensor<1,dim,real> &normal_int) const
 {
+    // See Blazek 2015, p.103-105
+    // -- Note: Modified calculation of alpha_{3,4} to use 
+    //          dVt (jump in tangential velocities);
+    //          expressions are equivalent
+    
     // Blazek 2015
     // p. 103-105
     // Note: This is in fact the Roe-Pike method of Roe & Pike (1984 - Efficient)
@@ -151,71 +273,28 @@ std::array<real, nstate> Roe<dim,nstate,real>
     eig_R[1] = abs(normal_vel_R);
     eig_R[2] = abs(normal_vel_R+sound_R);
 
-    // // Harten's entropy fix
-    // for(int e=0;e<3;e++) {
-    //     const real eps = std::max(abs(eig_ravg[e]-eig_L[e]), abs(eig_R[e]-eig_ravg[e]));
-    //     if(eig_ravg[e] < eps) {
-    //         eig_ravg[e] = 0.5*(eig_ravg[e]*eig_ravg[e]/eps + eps);
-    //     }
-    // }
-
-    // Van Leer et al. (1989 Sonic) entropy fix for acoustic waves -- double check with Osswald paper + van leer paper + cite it here
-    // -- p.74 of Osswald et al. (2016 L2Roe)
-    for(int e=0;e<3;e++) {
-        if(e!=1) {
-            // const real deig = std::max((eig_R[e]-eig_L[e]), 0.0);
-            const real deig = std::max(static_cast<real>(eig_R[e]-eig_L[e]), static_cast<real>(0.0));
-            if(eig_ravg[e] < 2.0*deig) {
-                eig_ravg[e] = 0.25*(eig_ravg[e]*eig_ravg[e]/deig) + deig;
-            }
-        }
-    }
-
-    // Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
-    // -- See also p.74 of Osswald et al. (2016 L2Roe)
-    int ssw_L=0, ssw_R=0;
-    // ssw_L: i=L --> j=R
-    if((eig_L[0]>0.0 && eig_R[0]<0.0) || (eig_L[2]>0.0 && eig_R[2]<0.0)) {
-        ssw_L = 1;
-    }
-    // ssw_R: i=R --> j=L
-    if((eig_R[0]>0.0 && eig_L[0]<0.0) || (eig_R[2]>0.0 && eig_L[2]<0.0)) {
-        ssw_R = 1;
-    }
-
-    // Entropy fix of Liou (2000 Mass)
-    // -- p.74 of Osswald et al. (2016 L2Roe)
-    if(ssw_L!=0 || ssw_R!=0) {
-        eig_ravg[1] = std::max(sound_ravg, static_cast<real>(sqrt(vel2_ravg)));
-    }
-
-    // Physical fluxes
-    const std::array<real,nstate> normal_flux_int = euler_physics->convective_normal_flux (soln_int, normal_int);
-    const std::array<real,nstate> normal_flux_ext = euler_physics->convective_normal_flux (soln_ext, normal_int);
-
-    real dVn = normal_vel_R-normal_vel_L;
+    // Jumps in pressure and density
     const real dp = pressure_R - pressure_L;
     const real drho = density_R - density_L;
 
-    // Jumps in tangential velocities -- testing
+    // Jump in normal velocity
+    real dVn = normal_vel_R-normal_vel_L;
+
+    // Jumps in tangential velocities
     dealii::Tensor<1,dim,real> dVt;
     for (int d=0;d<dim;d++) {
         dVt[d] = (velocities_R[d] - velocities_L[d]) - dVn*normal_int[d];
     }
 
-    // Osswald's two modifications to Roe-Pike scheme --> L2Roe
-    const real mach_number_L = euler_physics->compute_mach_number(soln_int);
-    const real mach_number_R = euler_physics->compute_mach_number(soln_ext);
-    const real blending_factor = std::min(static_cast<real>(1.0), std::max(mach_number_L,mach_number_R)); // 'z' variable in reference
-    // - Scale jump in (1) normal and (2) tangential velocities
-    if(ssw_L==0 && ssw_R==0)
-    {
-        dVn *= blending_factor;
-        for (int d=0;d<dim;d++)
-        { 
-            dVt[d] *= blending_factor;
-        }
-    }
+    // Evaluate entropy fix on wave speeds
+    evaluate_entropy_fix (eig_L, eig_R, eig_ravg, vel2_ravg, sound_ravg);
+
+    // Evaluate additional modifications to the Roe-Pike scheme (if applicable)
+    evaluate_additional_modifications (soln_int, soln_ext, eig_L, eig_R, dVn, dVt);
+
+    // Physical fluxes
+    const std::array<real,nstate> normal_flux_int = euler_physics->convective_normal_flux (soln_int, normal_int);
+    const std::array<real,nstate> normal_flux_ext = euler_physics->convective_normal_flux (soln_ext, normal_int);
 
     // Product of eigenvalues and wave strengths
     real coeff[4];
@@ -227,20 +306,21 @@ std::array<real, nstate> Roe<dim,nstate,real>
     // Evaluate |A_Roe| * (W_R - W_L)
     std::array<real,nstate> AdW;
 
-    // Vn-c
+    // Vn-c (i=1)
     AdW[0] = coeff[0] * 1.0;
     for (int d=0;d<dim;d++) {
         AdW[1+d] = coeff[0] * (velocities_ravg[d] - sound_ravg * normal_int[d]);
     }
     AdW[nstate-1] = coeff[0] * (specific_total_enthalpy_ravg - sound_ravg*normal_vel_ravg);
 
-    // Vn
+    // Vn (i=2)
     AdW[0] += coeff[1] * 1.0;
     for (int d=0;d<dim;d++) {
         AdW[1+d] += coeff[1] * velocities_ravg[d];
     }
     AdW[nstate-1] += coeff[1] * vel2_ravg * 0.5;
 
+    // (i=3,4)
     AdW[0] += coeff[2] * 0.0;
     // //const dealii::Tensor<1,dim,real> dvel = velocities_R - velocities_L;
     // dealii::Tensor<1,dim,real> dvel;
@@ -253,14 +333,14 @@ std::array<real, nstate> Roe<dim,nstate,real>
     //     dvel_dot_vel_ravg += velocities_ravg[d]*dvel[d];
     // }
     // AdW[nstate-1] += coeff[2] * (dvel_dot_vel_ravg - normal_vel_ravg*dVn);
-    real dVt_dot_vel_ravg = 0.0; // testing
+    real dVt_dot_vel_ravg = 0.0;// testing
     for (int d=0;d<dim;d++) {
         AdW[1+d] += coeff[2]*dVt[d]; // testing
         dVt_dot_vel_ravg += velocities_ravg[d]*dVt[d]; // testing
     }
     AdW[nstate-1] += coeff[2]*dVt_dot_vel_ravg; // testing
 
-    // Vn+c
+    // Vn+c (i=5)
     AdW[0] += coeff[3] * 1.0;
     for (int d=0;d<dim;d++) {
         AdW[1+d] += coeff[3] * (velocities_ravg[d] + sound_ravg * normal_int[d]);
@@ -274,6 +354,211 @@ std::array<real, nstate> Roe<dim,nstate,real>
 
     return numerical_flux_dot_n;
 }
+
+// template<int dim, int nstate, typename real>
+// std::array<real, nstate> Roe<dim,nstate,real>
+// ::evaluate_flux (
+//     const std::array<real, nstate> &soln_int,
+//     const std::array<real, nstate> &soln_ext,
+//     const dealii::Tensor<1,dim,real> &normal_int) const
+// {
+//     // Blazek 2015
+//     // p. 103-105
+//     // Note: This is in fact the Roe-Pike method of Roe & Pike (1984 - Efficient)
+//     const std::array<real,nstate> prim_soln_int = euler_physics->convert_conservative_to_primitive(soln_int);
+//     const std::array<real,nstate> prim_soln_ext = euler_physics->convert_conservative_to_primitive(soln_ext);
+//     // Left cell
+//     const real density_L = prim_soln_int[0];
+//     const dealii::Tensor< 1,dim,real > velocities_L = euler_physics->extract_velocities_from_primitive(prim_soln_int);
+//     const real pressure_L = prim_soln_int[nstate-1];
+
+//     //const real normal_vel_L = velocities_L*normal_int;
+//     real normal_vel_L = 0.0;
+//     for (int d=0; d<dim; ++d) {
+//         normal_vel_L+= velocities_L[d]*normal_int[d];
+//     }
+//     const real specific_enthalpy_L = euler_physics->compute_specific_enthalpy(soln_int, pressure_L);
+
+//     // Right cell
+//     const real density_R = prim_soln_ext[0];
+//     const dealii::Tensor< 1,dim,real > velocities_R = euler_physics->extract_velocities_from_primitive(prim_soln_ext);
+//     const real pressure_R = prim_soln_ext[nstate-1];
+
+//     //const real normal_vel_R = velocities_R*normal_int;
+//     real normal_vel_R = 0.0;
+//     for (int d=0; d<dim; ++d) {
+//         normal_vel_R+= velocities_R[d]*normal_int[d];
+//     }
+//     const real specific_enthalpy_R = euler_physics->compute_specific_enthalpy(soln_ext, pressure_R);
+
+//     // Roe-averaged states
+//     const real r = sqrt(density_R/density_L);
+//     const real rp1 = r+1.0;
+
+//     const real density_ravg = r*density_L;
+//     //const dealii::Tensor< 1,dim,real > velocities_ravg = (r*velocities_R + velocities_L) / rp1;
+//     dealii::Tensor< 1,dim,real > velocities_ravg;
+//     for (int d=0; d<dim; ++d) {
+//         velocities_ravg[d] = (r*velocities_R[d] + velocities_L[d]) / rp1;
+//     }
+//     const real specific_total_enthalpy_ravg = (r*specific_enthalpy_R + specific_enthalpy_L) / rp1;
+
+//     const real vel2_ravg = euler_physics->compute_velocity_squared (velocities_ravg);
+//     //const real normal_vel_ravg = velocities_ravg*normal_int;
+//     real normal_vel_ravg = 0.0;
+//     for (int d=0; d<dim; ++d) {
+//         normal_vel_ravg += velocities_ravg[d]*normal_int[d];
+//     }
+
+//     const real sound2_ravg = euler_physics->gamm1*(specific_total_enthalpy_ravg-0.5*vel2_ravg);
+//     real sound_ravg = 1e10;
+//     if (sound2_ravg > 0.0) {
+//         sound_ravg = sqrt(sound2_ravg);
+//     }
+
+//     // Compute eigenvalues
+//     std::array<real, 3> eig_ravg;
+//     eig_ravg[0] = abs(normal_vel_ravg-sound_ravg);
+//     eig_ravg[1] = abs(normal_vel_ravg);
+//     eig_ravg[2] = abs(normal_vel_ravg+sound_ravg);
+
+//     const real sound_L = euler_physics->compute_sound(density_L, pressure_L);
+//     std::array<real, 3> eig_L;
+//     eig_L[0] = abs(normal_vel_L-sound_L);
+//     eig_L[1] = abs(normal_vel_L);
+//     eig_L[2] = abs(normal_vel_L+sound_L);
+
+//     const real sound_R = euler_physics->compute_sound(density_R, pressure_R);
+//     std::array<real, 3> eig_R;
+//     eig_R[0] = abs(normal_vel_R-sound_R);
+//     eig_R[1] = abs(normal_vel_R);
+//     eig_R[2] = abs(normal_vel_R+sound_R);
+
+//     // // Harten's entropy fix
+//     // for(int e=0;e<3;e++) {
+//     //     const real eps = std::max(abs(eig_ravg[e]-eig_L[e]), abs(eig_R[e]-eig_ravg[e]));
+//     //     if(eig_ravg[e] < eps) {
+//     //         eig_ravg[e] = 0.5*(eig_ravg[e]*eig_ravg[e]/eps + eps);
+//     //     }
+//     // }
+
+//     // Van Leer et al. (1989 Sonic) entropy fix for acoustic waves -- double check with Osswald paper + van leer paper + cite it here
+//     // -- p.74 of Osswald et al. (2016 L2Roe)
+//     for(int e=0;e<3;e++) {
+//         if(e!=1) {
+//             // const real deig = std::max((eig_R[e]-eig_L[e]), 0.0);
+//             const real deig = std::max(static_cast<real>(eig_R[e]-eig_L[e]), static_cast<real>(0.0));
+//             if(eig_ravg[e] < 2.0*deig) {
+//                 eig_ravg[e] = 0.25*(eig_ravg[e]*eig_ravg[e]/deig) + deig;
+//             }
+//         }
+//     }
+
+//     // Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
+//     // -- See also p.74 of Osswald et al. (2016 L2Roe)
+//     int ssw_L=0, ssw_R=0;
+//     // ssw_L: i=L --> j=R
+//     if((eig_L[0]>0.0 && eig_R[0]<0.0) || (eig_L[2]>0.0 && eig_R[2]<0.0)) {
+//         ssw_L = 1;
+//     }
+//     // ssw_R: i=R --> j=L
+//     if((eig_R[0]>0.0 && eig_L[0]<0.0) || (eig_R[2]>0.0 && eig_L[2]<0.0)) {
+//         ssw_R = 1;
+//     }
+
+//     // Entropy fix of Liou (2000 Mass)
+//     // -- p.74 of Osswald et al. (2016 L2Roe)
+//     if(ssw_L!=0 || ssw_R!=0) {
+//         eig_ravg[1] = std::max(sound_ravg, static_cast<real>(sqrt(vel2_ravg)));
+//     }
+
+//     // Physical fluxes
+//     const std::array<real,nstate> normal_flux_int = euler_physics->convective_normal_flux (soln_int, normal_int);
+//     const std::array<real,nstate> normal_flux_ext = euler_physics->convective_normal_flux (soln_ext, normal_int);
+
+//     real dVn = normal_vel_R-normal_vel_L;
+//     const real dp = pressure_R - pressure_L;
+//     const real drho = density_R - density_L;
+
+//     // Jumps in tangential velocities -- testing
+//     dealii::Tensor<1,dim,real> dVt;
+//     for (int d=0;d<dim;d++) {
+//         dVt[d] = (velocities_R[d] - velocities_L[d]) - dVn*normal_int[d];
+//     }
+
+//     // Osswald's two modifications to Roe-Pike scheme --> L2Roe
+//     const real mach_number_L = euler_physics->compute_mach_number(soln_int);
+//     const real mach_number_R = euler_physics->compute_mach_number(soln_ext);
+//     const real blending_factor = std::min(static_cast<real>(1.0), std::max(mach_number_L,mach_number_R)); // 'z' variable in reference
+//     // - Scale jump in (1) normal and (2) tangential velocities
+//     if(ssw_L==0 && ssw_R==0)
+//     {
+//         dVn *= blending_factor;
+//         for (int d=0;d<dim;d++)
+//         { 
+//             dVt[d] *= blending_factor;
+//         }
+//     }
+
+//     // Product of eigenvalues and wave strengths
+//     real coeff[4];
+//     coeff[0] = eig_ravg[0]*(dp-density_ravg*sound_ravg*dVn)/(2.0*sound2_ravg);
+//     coeff[1] = eig_ravg[1]*(drho - dp/sound2_ravg);
+//     coeff[2] = eig_ravg[1]*density_ravg;
+//     coeff[3] = eig_ravg[2]*(dp+density_ravg*sound_ravg*dVn)/(2.0*sound2_ravg);
+
+//     // Evaluate |A_Roe| * (W_R - W_L)
+//     std::array<real,nstate> AdW;
+
+//     // Vn-c
+//     AdW[0] = coeff[0] * 1.0;
+//     for (int d=0;d<dim;d++) {
+//         AdW[1+d] = coeff[0] * (velocities_ravg[d] - sound_ravg * normal_int[d]);
+//     }
+//     AdW[nstate-1] = coeff[0] * (specific_total_enthalpy_ravg - sound_ravg*normal_vel_ravg);
+
+//     // Vn
+//     AdW[0] += coeff[1] * 1.0;
+//     for (int d=0;d<dim;d++) {
+//         AdW[1+d] += coeff[1] * velocities_ravg[d];
+//     }
+//     AdW[nstate-1] += coeff[1] * vel2_ravg * 0.5;
+
+//     AdW[0] += coeff[2] * 0.0;
+//     // //const dealii::Tensor<1,dim,real> dvel = velocities_R - velocities_L;
+//     // dealii::Tensor<1,dim,real> dvel;
+//     // for (int d=0; d<dim; ++d) {
+//     //     dvel[d] = velocities_R[d] - velocities_L[d];
+//     // }
+//     // real dvel_dot_vel_ravg = 0.0;
+//     // for (int d=0;d<dim;d++) {
+//     //     AdW[1+d] += coeff[2] * (dvel[d] - dVn*normal_int[d]);
+//     //     dvel_dot_vel_ravg += velocities_ravg[d]*dvel[d];
+//     // }
+//     // AdW[nstate-1] += coeff[2] * (dvel_dot_vel_ravg - normal_vel_ravg*dVn);
+//     real dVt_dot_vel_ravg = 0.0; // testing
+//     for (int d=0;d<dim;d++) {
+//         AdW[1+d] += coeff[2]*dVt[d]; // testing
+//         dVt_dot_vel_ravg += velocities_ravg[d]*dVt[d]; // testing
+//     }
+//     AdW[nstate-1] += coeff[2]*dVt_dot_vel_ravg; // testing
+
+//     // Vn+c
+//     AdW[0] += coeff[3] * 1.0;
+//     for (int d=0;d<dim;d++) {
+//         AdW[1+d] += coeff[3] * (velocities_ravg[d] + sound_ravg * normal_int[d]);
+//     }
+//     AdW[nstate-1] += coeff[3] * (specific_total_enthalpy_ravg + sound_ravg*normal_vel_ravg);
+
+//     std::array<real, nstate> numerical_flux_dot_n;
+//     for (int s=0; s<nstate; s++) {
+//         numerical_flux_dot_n[s] = 0.5*(normal_flux_int[s]+normal_flux_ext[s] - AdW[s]);
+//     }
+
+//     return numerical_flux_dot_n;
+// }
+
+
 
 
 // Instantiation
@@ -330,11 +615,28 @@ template class LaxFriedrichs<PHILIP_DIM, 3, RadFadType >;
 template class LaxFriedrichs<PHILIP_DIM, 4, RadFadType >;
 template class LaxFriedrichs<PHILIP_DIM, 5, RadFadType >;
 
-template class Roe<PHILIP_DIM, PHILIP_DIM+2, double>;
-template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadType >;
-template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadType >;
-template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
-template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
+// template class Roe<PHILIP_DIM, PHILIP_DIM+2, double>;
+// template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadType >;
+// template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadType >;
+// template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
+// template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
+
+template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, double>;
+template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, FadType >;
+template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, RadType >;
+template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
+template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
+
+template class RoePike<PHILIP_DIM, PHILIP_DIM+2, double>;
+template class RoePike<PHILIP_DIM, PHILIP_DIM+2, FadType >;
+template class RoePike<PHILIP_DIM, PHILIP_DIM+2, RadType >;
+template class RoePike<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
+template class RoePike<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
+template class L2Roe<PHILIP_DIM, PHILIP_DIM+2, double>;
+template class L2Roe<PHILIP_DIM, PHILIP_DIM+2, FadType >;
+template class L2Roe<PHILIP_DIM, PHILIP_DIM+2, RadType >;
+template class L2Roe<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
+template class L2Roe<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
 
 
 } // NumericalFlux namespace

--- a/src/numerical_flux/convective_numerical_flux.cpp
+++ b/src/numerical_flux/convective_numerical_flux.cpp
@@ -188,7 +188,6 @@ void L2Roe<dim,nstate,real>
     }
 }
 
-// Compute the flux equation
 template <int dim, int nstate, typename real>
 std::array<real, nstate> RoeBase<dim,nstate,real>
 ::evaluate_flux (
@@ -322,23 +321,12 @@ std::array<real, nstate> RoeBase<dim,nstate,real>
 
     // (i=3,4)
     AdW[0] += coeff[2] * 0.0;
-    // //const dealii::Tensor<1,dim,real> dvel = velocities_R - velocities_L;
-    // dealii::Tensor<1,dim,real> dvel;
-    // for (int d=0; d<dim; ++d) {
-    //     dvel[d] = velocities_R[d] - velocities_L[d];
-    // }
-    // real dvel_dot_vel_ravg = 0.0;
-    // for (int d=0;d<dim;d++) {
-    //     AdW[1+d] += coeff[2] * (dvel[d] - dVn*normal_int[d]);
-    //     dvel_dot_vel_ravg += velocities_ravg[d]*dvel[d];
-    // }
-    // AdW[nstate-1] += coeff[2] * (dvel_dot_vel_ravg - normal_vel_ravg*dVn);
-    real dVt_dot_vel_ravg = 0.0;// testing
+    real dVt_dot_vel_ravg = 0.0;
     for (int d=0;d<dim;d++) {
-        AdW[1+d] += coeff[2]*dVt[d]; // testing
-        dVt_dot_vel_ravg += velocities_ravg[d]*dVt[d]; // testing
+        AdW[1+d] += coeff[2]*dVt[d];
+        dVt_dot_vel_ravg += velocities_ravg[d]*dVt[d];
     }
-    AdW[nstate-1] += coeff[2]*dVt_dot_vel_ravg; // testing
+    AdW[nstate-1] += coeff[2]*dVt_dot_vel_ravg;
 
     // Vn+c (i=5)
     AdW[0] += coeff[3] * 1.0;
@@ -354,212 +342,6 @@ std::array<real, nstate> RoeBase<dim,nstate,real>
 
     return numerical_flux_dot_n;
 }
-
-// template<int dim, int nstate, typename real>
-// std::array<real, nstate> Roe<dim,nstate,real>
-// ::evaluate_flux (
-//     const std::array<real, nstate> &soln_int,
-//     const std::array<real, nstate> &soln_ext,
-//     const dealii::Tensor<1,dim,real> &normal_int) const
-// {
-//     // Blazek 2015
-//     // p. 103-105
-//     // Note: This is in fact the Roe-Pike method of Roe & Pike (1984 - Efficient)
-//     const std::array<real,nstate> prim_soln_int = euler_physics->convert_conservative_to_primitive(soln_int);
-//     const std::array<real,nstate> prim_soln_ext = euler_physics->convert_conservative_to_primitive(soln_ext);
-//     // Left cell
-//     const real density_L = prim_soln_int[0];
-//     const dealii::Tensor< 1,dim,real > velocities_L = euler_physics->extract_velocities_from_primitive(prim_soln_int);
-//     const real pressure_L = prim_soln_int[nstate-1];
-
-//     //const real normal_vel_L = velocities_L*normal_int;
-//     real normal_vel_L = 0.0;
-//     for (int d=0; d<dim; ++d) {
-//         normal_vel_L+= velocities_L[d]*normal_int[d];
-//     }
-//     const real specific_enthalpy_L = euler_physics->compute_specific_enthalpy(soln_int, pressure_L);
-
-//     // Right cell
-//     const real density_R = prim_soln_ext[0];
-//     const dealii::Tensor< 1,dim,real > velocities_R = euler_physics->extract_velocities_from_primitive(prim_soln_ext);
-//     const real pressure_R = prim_soln_ext[nstate-1];
-
-//     //const real normal_vel_R = velocities_R*normal_int;
-//     real normal_vel_R = 0.0;
-//     for (int d=0; d<dim; ++d) {
-//         normal_vel_R+= velocities_R[d]*normal_int[d];
-//     }
-//     const real specific_enthalpy_R = euler_physics->compute_specific_enthalpy(soln_ext, pressure_R);
-
-//     // Roe-averaged states
-//     const real r = sqrt(density_R/density_L);
-//     const real rp1 = r+1.0;
-
-//     const real density_ravg = r*density_L;
-//     //const dealii::Tensor< 1,dim,real > velocities_ravg = (r*velocities_R + velocities_L) / rp1;
-//     dealii::Tensor< 1,dim,real > velocities_ravg;
-//     for (int d=0; d<dim; ++d) {
-//         velocities_ravg[d] = (r*velocities_R[d] + velocities_L[d]) / rp1;
-//     }
-//     const real specific_total_enthalpy_ravg = (r*specific_enthalpy_R + specific_enthalpy_L) / rp1;
-
-//     const real vel2_ravg = euler_physics->compute_velocity_squared (velocities_ravg);
-//     //const real normal_vel_ravg = velocities_ravg*normal_int;
-//     real normal_vel_ravg = 0.0;
-//     for (int d=0; d<dim; ++d) {
-//         normal_vel_ravg += velocities_ravg[d]*normal_int[d];
-//     }
-
-//     const real sound2_ravg = euler_physics->gamm1*(specific_total_enthalpy_ravg-0.5*vel2_ravg);
-//     real sound_ravg = 1e10;
-//     if (sound2_ravg > 0.0) {
-//         sound_ravg = sqrt(sound2_ravg);
-//     }
-
-//     // Compute eigenvalues
-//     std::array<real, 3> eig_ravg;
-//     eig_ravg[0] = abs(normal_vel_ravg-sound_ravg);
-//     eig_ravg[1] = abs(normal_vel_ravg);
-//     eig_ravg[2] = abs(normal_vel_ravg+sound_ravg);
-
-//     const real sound_L = euler_physics->compute_sound(density_L, pressure_L);
-//     std::array<real, 3> eig_L;
-//     eig_L[0] = abs(normal_vel_L-sound_L);
-//     eig_L[1] = abs(normal_vel_L);
-//     eig_L[2] = abs(normal_vel_L+sound_L);
-
-//     const real sound_R = euler_physics->compute_sound(density_R, pressure_R);
-//     std::array<real, 3> eig_R;
-//     eig_R[0] = abs(normal_vel_R-sound_R);
-//     eig_R[1] = abs(normal_vel_R);
-//     eig_R[2] = abs(normal_vel_R+sound_R);
-
-//     // // Harten's entropy fix
-//     // for(int e=0;e<3;e++) {
-//     //     const real eps = std::max(abs(eig_ravg[e]-eig_L[e]), abs(eig_R[e]-eig_ravg[e]));
-//     //     if(eig_ravg[e] < eps) {
-//     //         eig_ravg[e] = 0.5*(eig_ravg[e]*eig_ravg[e]/eps + eps);
-//     //     }
-//     // }
-
-//     // Van Leer et al. (1989 Sonic) entropy fix for acoustic waves -- double check with Osswald paper + van leer paper + cite it here
-//     // -- p.74 of Osswald et al. (2016 L2Roe)
-//     for(int e=0;e<3;e++) {
-//         if(e!=1) {
-//             // const real deig = std::max((eig_R[e]-eig_L[e]), 0.0);
-//             const real deig = std::max(static_cast<real>(eig_R[e]-eig_L[e]), static_cast<real>(0.0));
-//             if(eig_ravg[e] < 2.0*deig) {
-//                 eig_ravg[e] = 0.25*(eig_ravg[e]*eig_ravg[e]/deig) + deig;
-//             }
-//         }
-//     }
-
-//     // Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
-//     // -- See also p.74 of Osswald et al. (2016 L2Roe)
-//     int ssw_L=0, ssw_R=0;
-//     // ssw_L: i=L --> j=R
-//     if((eig_L[0]>0.0 && eig_R[0]<0.0) || (eig_L[2]>0.0 && eig_R[2]<0.0)) {
-//         ssw_L = 1;
-//     }
-//     // ssw_R: i=R --> j=L
-//     if((eig_R[0]>0.0 && eig_L[0]<0.0) || (eig_R[2]>0.0 && eig_L[2]<0.0)) {
-//         ssw_R = 1;
-//     }
-
-//     // Entropy fix of Liou (2000 Mass)
-//     // -- p.74 of Osswald et al. (2016 L2Roe)
-//     if(ssw_L!=0 || ssw_R!=0) {
-//         eig_ravg[1] = std::max(sound_ravg, static_cast<real>(sqrt(vel2_ravg)));
-//     }
-
-//     // Physical fluxes
-//     const std::array<real,nstate> normal_flux_int = euler_physics->convective_normal_flux (soln_int, normal_int);
-//     const std::array<real,nstate> normal_flux_ext = euler_physics->convective_normal_flux (soln_ext, normal_int);
-
-//     real dVn = normal_vel_R-normal_vel_L;
-//     const real dp = pressure_R - pressure_L;
-//     const real drho = density_R - density_L;
-
-//     // Jumps in tangential velocities -- testing
-//     dealii::Tensor<1,dim,real> dVt;
-//     for (int d=0;d<dim;d++) {
-//         dVt[d] = (velocities_R[d] - velocities_L[d]) - dVn*normal_int[d];
-//     }
-
-//     // Osswald's two modifications to Roe-Pike scheme --> L2Roe
-//     const real mach_number_L = euler_physics->compute_mach_number(soln_int);
-//     const real mach_number_R = euler_physics->compute_mach_number(soln_ext);
-//     const real blending_factor = std::min(static_cast<real>(1.0), std::max(mach_number_L,mach_number_R)); // 'z' variable in reference
-//     // - Scale jump in (1) normal and (2) tangential velocities
-//     if(ssw_L==0 && ssw_R==0)
-//     {
-//         dVn *= blending_factor;
-//         for (int d=0;d<dim;d++)
-//         { 
-//             dVt[d] *= blending_factor;
-//         }
-//     }
-
-//     // Product of eigenvalues and wave strengths
-//     real coeff[4];
-//     coeff[0] = eig_ravg[0]*(dp-density_ravg*sound_ravg*dVn)/(2.0*sound2_ravg);
-//     coeff[1] = eig_ravg[1]*(drho - dp/sound2_ravg);
-//     coeff[2] = eig_ravg[1]*density_ravg;
-//     coeff[3] = eig_ravg[2]*(dp+density_ravg*sound_ravg*dVn)/(2.0*sound2_ravg);
-
-//     // Evaluate |A_Roe| * (W_R - W_L)
-//     std::array<real,nstate> AdW;
-
-//     // Vn-c
-//     AdW[0] = coeff[0] * 1.0;
-//     for (int d=0;d<dim;d++) {
-//         AdW[1+d] = coeff[0] * (velocities_ravg[d] - sound_ravg * normal_int[d]);
-//     }
-//     AdW[nstate-1] = coeff[0] * (specific_total_enthalpy_ravg - sound_ravg*normal_vel_ravg);
-
-//     // Vn
-//     AdW[0] += coeff[1] * 1.0;
-//     for (int d=0;d<dim;d++) {
-//         AdW[1+d] += coeff[1] * velocities_ravg[d];
-//     }
-//     AdW[nstate-1] += coeff[1] * vel2_ravg * 0.5;
-
-//     AdW[0] += coeff[2] * 0.0;
-//     // //const dealii::Tensor<1,dim,real> dvel = velocities_R - velocities_L;
-//     // dealii::Tensor<1,dim,real> dvel;
-//     // for (int d=0; d<dim; ++d) {
-//     //     dvel[d] = velocities_R[d] - velocities_L[d];
-//     // }
-//     // real dvel_dot_vel_ravg = 0.0;
-//     // for (int d=0;d<dim;d++) {
-//     //     AdW[1+d] += coeff[2] * (dvel[d] - dVn*normal_int[d]);
-//     //     dvel_dot_vel_ravg += velocities_ravg[d]*dvel[d];
-//     // }
-//     // AdW[nstate-1] += coeff[2] * (dvel_dot_vel_ravg - normal_vel_ravg*dVn);
-//     real dVt_dot_vel_ravg = 0.0; // testing
-//     for (int d=0;d<dim;d++) {
-//         AdW[1+d] += coeff[2]*dVt[d]; // testing
-//         dVt_dot_vel_ravg += velocities_ravg[d]*dVt[d]; // testing
-//     }
-//     AdW[nstate-1] += coeff[2]*dVt_dot_vel_ravg; // testing
-
-//     // Vn+c
-//     AdW[0] += coeff[3] * 1.0;
-//     for (int d=0;d<dim;d++) {
-//         AdW[1+d] += coeff[3] * (velocities_ravg[d] + sound_ravg * normal_int[d]);
-//     }
-//     AdW[nstate-1] += coeff[3] * (specific_total_enthalpy_ravg + sound_ravg*normal_vel_ravg);
-
-//     std::array<real, nstate> numerical_flux_dot_n;
-//     for (int s=0; s<nstate; s++) {
-//         numerical_flux_dot_n[s] = 0.5*(normal_flux_int[s]+normal_flux_ext[s] - AdW[s]);
-//     }
-
-//     return numerical_flux_dot_n;
-// }
-
-
-
 
 // Instantiation
 template class NumericalFluxConvective<PHILIP_DIM, 1, double>;
@@ -614,12 +396,6 @@ template class LaxFriedrichs<PHILIP_DIM, 2, RadFadType >;
 template class LaxFriedrichs<PHILIP_DIM, 3, RadFadType >;
 template class LaxFriedrichs<PHILIP_DIM, 4, RadFadType >;
 template class LaxFriedrichs<PHILIP_DIM, 5, RadFadType >;
-
-// template class Roe<PHILIP_DIM, PHILIP_DIM+2, double>;
-// template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadType >;
-// template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadType >;
-// template class Roe<PHILIP_DIM, PHILIP_DIM+2, FadFadType >;
-// template class Roe<PHILIP_DIM, PHILIP_DIM+2, RadFadType >;
 
 template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, double>;
 template class RoeBase<PHILIP_DIM, PHILIP_DIM+2, FadType >;

--- a/src/numerical_flux/convective_numerical_flux.hpp
+++ b/src/numerical_flux/convective_numerical_flux.hpp
@@ -68,7 +68,6 @@ public:
 	{};
 
     /// Virtual destructor required for abstract classes.
-	/// virtual ~RoeBase() = 0;
 	~RoeBase() {};
 
 	virtual void evaluate_entropy_fix (
@@ -98,12 +97,9 @@ template<int dim, int nstate, typename real>
 class RoePike: public RoeBase<dim, nstate, real>
 {
 public:
-	/// Constructor -- confirm with Doug
+	/// Constructor
 	RoePike(std::shared_ptr <Physics::PhysicsBase<dim, nstate, real>> physics_input)
 		:	RoeBase<dim, nstate, real>(physics_input){}
-
-	/// Destructor
-	///~RoePike () {};
 
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
@@ -126,12 +122,9 @@ template<int dim, int nstate, typename real>
 class L2Roe: public RoeBase<dim, nstate, real>
 {
 public:
-	/// Constructor -- confirm with Doug
+	/// Constructor
 	L2Roe(std::shared_ptr <Physics::PhysicsBase<dim, nstate, real>> physics_input)
 		:	RoeBase<dim, nstate, real>(physics_input){}
-
-	/// Destructor
-	///~L2Roe () {};
 
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
@@ -148,7 +141,7 @@ public:
 	    real &dV_normal, 
 	    dealii::Tensor<1,dim,real> &dV_tangent) const;
 
-protected: /// ask Doug if below has to be public
+protected:
 	void evaluate_shock_indicator(
 		const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,

--- a/src/numerical_flux/convective_numerical_flux.hpp
+++ b/src/numerical_flux/convective_numerical_flux.hpp
@@ -52,7 +52,7 @@ const std::shared_ptr < Physics::PhysicsBase<dim, nstate, real> > pde_physics;
 
 };
 
-/// Base class of Roe flux with entropy fix. Derived from NumericalFluxConvective.
+/// Base class of Roe (Roe-Pike) flux with entropy fix. Derived from NumericalFluxConvective.
 template<int dim, int nstate, typename real>
 class RoeBase: public NumericalFluxConvective<dim, nstate, real>
 {
@@ -67,9 +67,10 @@ public:
 	euler_physics(std::dynamic_pointer_cast<Physics::Euler<dim,nstate,real>>(physics_input))
 	{};
 
-    /// Virtual destructor required for abstract classes.
+    /// Destructor
 	~RoeBase() {};
 
+	/// Virtual member function for evaluating the entropy fix for a Roe-Pike flux.
 	virtual void evaluate_entropy_fix (
 	    const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,
@@ -77,6 +78,7 @@ public:
 	    const real vel2_ravg,
 	    const real sound_ravg) const = 0;
 
+	/// Virtual member function for evaluating additional modifications/corrections for a Roe-Pike flux.
 	virtual void evaluate_additional_modifications (
 	    const std::array<real, nstate> &soln_int,
 	    const std::array<real, nstate> &soln_ext,
@@ -86,6 +88,10 @@ public:
 	    dealii::Tensor<1,dim,real> &dV_tangent) const = 0;
 
 	/// Returns the convective flux at an interface
+	/// --- See Blazek 2015, p.103-105
+	/// --- Note: Modified calculation of alpha_{3,4} to use 
+    ///           dVt (jump in tangential velocities);
+    ///           expressions are equivalent.
 	std::array<real, nstate> evaluate_flux (
 	    const std::array<real, nstate> &soln_int,
 	    const std::array<real, nstate> &soln_ext,
@@ -101,6 +107,8 @@ public:
 	RoePike(std::shared_ptr <Physics::PhysicsBase<dim, nstate, real>> physics_input)
 		:	RoeBase<dim, nstate, real>(physics_input){}
 
+	/// Evaluates the entropy fix of Harten
+    /// --- See Blazek 2015, p.103-105
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,
@@ -108,6 +116,7 @@ public:
 	    const real vel2_ravg,
 	    const real sound_ravg) const;
 
+	/// Empty function. No additional modifications for the Roe-Pike scheme.
 	void evaluate_additional_modifications(
 	    const std::array<real, nstate> &soln_int,
 	    const std::array<real, nstate> &soln_ext,
@@ -118,6 +127,7 @@ public:
 };
 
 /// L2Roe flux with entropy fix. Derived from RoeBase.
+/// --- Reference: Osswald et al. (2016 L2Roe)
 template<int dim, int nstate, typename real>
 class L2Roe: public RoeBase<dim, nstate, real>
 {
@@ -126,6 +136,9 @@ public:
 	L2Roe(std::shared_ptr <Physics::PhysicsBase<dim, nstate, real>> physics_input)
 		:	RoeBase<dim, nstate, real>(physics_input){}
 
+	/// (1) Van Leer et al. (1989 Sonic) entropy fix for acoustic waves (i.e. i=1,5)
+	/// (2) For waves (i=2,3,4) --> Entropy fix of Liou (2000 Mass)
+    /// --- See p.74 of Osswald et al. (2016 L2Roe)
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,
@@ -133,6 +146,8 @@ public:
 	    const real vel2_ravg,
 	    const real sound_ravg) const;
 	
+	/// Osswald's two modifications to Roe-Pike scheme --> L2Roe
+	/// --- Scale jump in (1) normal and (2) tangential velocities using a blending factor
 	void evaluate_additional_modifications(
 	    const std::array<real, nstate> &soln_int,
 	    const std::array<real, nstate> &soln_ext,
@@ -142,6 +157,8 @@ public:
 	    dealii::Tensor<1,dim,real> &dV_tangent) const;
 
 protected:
+	/// Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
+    /// --- See also p.74 of Osswald et al. (2016 L2Roe)
 	void evaluate_shock_indicator(
 		const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,

--- a/src/numerical_flux/convective_numerical_flux.hpp
+++ b/src/numerical_flux/convective_numerical_flux.hpp
@@ -67,7 +67,7 @@ public:
 	euler_physics(std::dynamic_pointer_cast<Physics::Euler<dim,nstate,real>>(physics_input))
 	{};
 
-    /// Destructor
+	/// Destructor
 	~RoeBase() {};
 
 	/// Virtual member function for evaluating the entropy fix for a Roe-Pike flux.
@@ -90,8 +90,8 @@ public:
 	/// Returns the convective flux at an interface
 	/// --- See Blazek 2015, p.103-105
 	/// --- Note: Modified calculation of alpha_{3,4} to use 
-    ///           dVt (jump in tangential velocities);
-    ///           expressions are equivalent.
+	///           dVt (jump in tangential velocities);
+	///           expressions are equivalent.
 	std::array<real, nstate> evaluate_flux (
 	    const std::array<real, nstate> &soln_int,
 	    const std::array<real, nstate> &soln_ext,
@@ -108,7 +108,7 @@ public:
 		:	RoeBase<dim, nstate, real>(physics_input){}
 
 	/// Evaluates the entropy fix of Harten
-    /// --- See Blazek 2015, p.103-105
+	/// --- See Blazek 2015, p.103-105
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,
@@ -138,7 +138,7 @@ public:
 
 	/// (1) Van Leer et al. (1989 Sonic) entropy fix for acoustic waves (i.e. i=1,5)
 	/// (2) For waves (i=2,3,4) --> Entropy fix of Liou (2000 Mass)
-    /// --- See p.74 of Osswald et al. (2016 L2Roe)
+	/// --- See p.74 of Osswald et al. (2016 L2Roe)
 	void evaluate_entropy_fix(
 	    const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,
@@ -158,7 +158,7 @@ public:
 
 protected:
 	/// Shock indicator of Wada & Liou (1994 Flux) -- Eq.(39)
-    /// --- See also p.74 of Osswald et al. (2016 L2Roe)
+	/// --- See also p.74 of Osswald et al. (2016 L2Roe)
 	void evaluate_shock_indicator(
 		const std::array<real, 3> &eig_L,
 	    const std::array<real, 3> &eig_R,

--- a/src/numerical_flux/numerical_flux_factory.cpp
+++ b/src/numerical_flux/numerical_flux_factory.cpp
@@ -18,7 +18,9 @@ NumericalFluxFactory<dim, nstate, real>
     if(conv_num_flux_type == AllParam::lax_friedrichs) {
         return std::make_unique< LaxFriedrichs<dim, nstate, real> > (physics_input);
     } else if(conv_num_flux_type == AllParam::roe) {
-        if constexpr (dim+2==nstate) return std::make_unique< Roe<dim, nstate, real> > (physics_input);
+        if constexpr (dim+2==nstate) return std::make_unique< RoePike<dim, nstate, real> > (physics_input);
+    } else if(conv_num_flux_type == AllParam::l2roe) {
+        if constexpr (dim+2==nstate) return std::make_unique< L2Roe<dim, nstate, real> > (physics_input);
     } else if (conv_num_flux_type == AllParam::split_form) {
         return std::make_unique< SplitFormNumFlux<dim, nstate, real> > (physics_input);
     }

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -125,9 +125,9 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       "  mhd>.");
     
     prm.declare_entry("conv_num_flux", "lax_friedrichs",
-                      dealii::Patterns::Selection("lax_friedrichs | roe | split_form"),
+                      dealii::Patterns::Selection("lax_friedrichs | roe | l2roe | split_form"),
                       "Convective numerical flux. "
-                      "Choices are <lax_friedrichs | roe | split_form>.");
+                      "Choices are <lax_friedrichs | roe | l2roe | split_form>.");
 
     prm.declare_entry("diss_num_flux", "symm_internal_penalty",
                       dealii::Patterns::Selection("symm_internal_penalty | bassi_rebay_2"),
@@ -209,6 +209,7 @@ void AllParameters::parse_parameters (dealii::ParameterHandler &prm)
     if (conv_num_flux_string == "lax_friedrichs") conv_num_flux_type = lax_friedrichs;
     if (conv_num_flux_string == "split_form")     conv_num_flux_type = split_form;
     if (conv_num_flux_string == "roe")            conv_num_flux_type = roe;
+    if (conv_num_flux_string == "l2roe")            conv_num_flux_type = l2roe;
 
     const std::string diss_num_flux_string = prm.get("diss_num_flux");
     if (diss_num_flux_string == "symm_internal_penalty") diss_num_flux_type = symm_internal_penalty;

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -132,7 +132,12 @@ public:
 
 
     /// Currently only Lax-Friedrichs, roe, and split_form can be used as an input parameter
-    enum ConvectiveNumericalFlux { lax_friedrichs, roe, split_form};
+    enum ConvectiveNumericalFlux { 
+        lax_friedrichs, 
+        roe, 
+        l2roe, 
+        split_form
+    };
 
     /// Store convective flux type
     ConvectiveNumericalFlux conv_num_flux_type;

--- a/tests/integration_tests_control_files/euler_integration/1d_euler_l2roe_manufactured.prm
+++ b/tests/integration_tests_control_files/euler_integration/1d_euler_l2roe_manufactured.prm
@@ -1,0 +1,51 @@
+# Listing of Parameters
+# ---------------------
+# Number of dimensions
+set dimension = 1
+
+set pde_type  = euler
+
+set conv_num_flux  = l2roe
+
+subsection ODE solver
+
+  set ode_output                          = verbose
+
+  set initial_time_step = 1000
+  set time_step_factor_residual = 10
+  set time_step_factor_residual_exp = 2
+
+  # Maximum nonlinear solver iterations
+  set nonlinear_max_iterations            = 500000
+
+  # Nonlinear solver residual tolerance
+  set nonlinear_steady_residual_tolerance = 1e-12
+
+  # Print every print_iteration_modulo iterations of the nonlinear solver
+  set print_iteration_modulo              = 1
+
+  # Explicit or implicit solverChoices are <explicit|implicit>.
+  set ode_solver_type                         = implicit
+end
+
+subsection manufactured solution convergence study
+  set use_manufactured_source_term = true
+  # Last degree used for convergence study
+  set degree_end        = 3
+
+  # Starting degree for convergence study
+  set degree_start      = 0
+
+  # Multiplier on grid size. nth-grid will be of size
+  # (initial_grid^grid_progression)^dim
+  set grid_progression  = 2
+
+  set grid_progression_add  = 5
+  # Initial grid of size (initial_grid_size)^dim
+  set initial_grid_size = 10
+
+  # Number of grids in grid study
+  set number_of_grids   = 4
+
+  set slope_deficit_tolerance = 0.2
+end

--- a/tests/integration_tests_control_files/euler_integration/2d_euler_l2roe_manufactured.prm
+++ b/tests/integration_tests_control_files/euler_integration/2d_euler_l2roe_manufactured.prm
@@ -1,0 +1,59 @@
+# Listing of Parameters
+# ---------------------
+# Number of dimensions
+set dimension = 2
+
+set pde_type  = euler
+
+set conv_num_flux  = l2roe
+
+subsection ODE solver
+  # Maximum nonlinear solver iterations
+  set nonlinear_max_iterations            = 100
+
+  # Nonlinear solver residual tolerance
+  set nonlinear_steady_residual_tolerance = 1e-14
+
+  set initial_time_step = 1000
+  set time_step_factor_residual = 20.0
+  set time_step_factor_residual_exp = 2.0
+
+  # Print every print_iteration_modulo iterations of the nonlinear solver
+  set print_iteration_modulo              = 1
+
+  # Explicit or implicit solverChoices are <explicit|implicit>.
+  set ode_solver_type                         = implicit
+end
+
+subsection linear solver
+  subsection gmres options
+    set max_iterations = 200
+    set linear_residual_tolerance = 1e-4
+    set restart_number = 60
+  end
+end
+
+subsection manufactured solution convergence study
+  set use_manufactured_source_term = true
+  # Last degree used for convergence study
+  set degree_end        = 3
+
+  # Starting degree for convergence study
+  set degree_start      = 0
+
+  set grid_progression  = 1.0
+
+  set grid_progression_add  = 5
+
+  # Initial grid of size (initial_grid_size)^dim
+  set initial_grid_size = 5
+
+  # Number of grids in grid study
+  set number_of_grids   = 4
+
+  # WARNING
+  # If we want actual optimal orders with a tigher tolerance
+  # we need to increase the grid sizes by a significant amount
+  set slope_deficit_tolerance = 0.1
+end
+

--- a/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
@@ -49,10 +49,24 @@ add_test(
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
 
+configure_file(1d_euler_l2roe_manufactured.prm 1d_euler_l2roe_manufactured.prm COPYONLY)
+add_test(
+  NAME 1D_EULER_L2ROE_MANUFACTURED_SOLUTION_LONG
+  COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_euler_l2roe_manufactured.prm
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+
 configure_file(2d_euler_roe_manufactured.prm 2d_euler_roe_manufactured.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_ROE_MANUFACTURED_SOLUTION_MEDIUM
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_roe_manufactured.prm
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+
+configure_file(2d_euler_l2roe_manufactured.prm 2d_euler_l2roe_manufactured.prm COPYONLY)
+add_test(
+  NAME MPI_2D_EULER_L2ROE_MANUFACTURED_SOLUTION_MEDIUM
+  COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_l2roe_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
 

--- a/tests/unit_tests/numerical_flux/numerical_flux_conservation.cpp
+++ b/tests/unit_tests/numerical_flux/numerical_flux_conservation.cpp
@@ -242,7 +242,8 @@ int main (int argc, char * argv[])
 
     std::vector<ConvType> conv_type {
         ConvType::lax_friedrichs,
-        ConvType::roe
+        ConvType::roe,
+        ConvType::l2roe
     };
     std::vector<DissType> diss_type {
         DissType::symm_internal_penalty
@@ -261,7 +262,7 @@ int main (int argc, char * argv[])
 
         for (auto conv = conv_type.begin(); conv != conv_type.end() && success == 0; conv++) {
 
-            if((*conv == ConvType::roe) && (*pde!=PDEType::euler)) continue;
+            if(((*conv == ConvType::roe) || (*conv == ConvType::l2roe)) && (*pde!=PDEType::euler)) continue;
 
             all_parameters.conv_num_flux_type = *conv;
 


### PR DESCRIPTION
Pull request to incorporate the addition of the low dissipation Roe flux (L2Roe) `L2Roe` of Osswald et al. (2016); the numerical flux is based on the Roe-Pike flux and is for low Mach number flows. 

Summary:

- The `Roe` class is now replaced by `RoeBase` to derive `RoePike` (same flux as original `Roe`) and `L2Roe`, each having their own `evaluate_entropy_fix` and `evaluate_additional_modifications`. 
- `L2Roe` added to the `numerical_flux_conservation.cpp` integration test
- Euler integration tests added for `L2Roe`: `1D_EULER_L2ROE_MANUFACTURED_SOLUTION_LONG` and `MPI_2D_EULER_L2ROE_MANUFACTURED_SOLUTION_MEDIUM` 