### PR TITLE
NACA0012 Mesh Files Intall Instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,12 @@ The deal.II library has been setup with the following options:
 
 This section is aimed at McGill's group who use the Compute Canada (CC) clusters.
 
-If you are a new user on a CC cluster, you must configure git modules by explicitly running the following on the cluster before proceeding:
+If you have just cloned the code onto the cluster, **you must copy the large NACA0012 mesh files** that cannot be stored on GitHub, this can be done by running the following:
+~~~~
+chmod +x get_NACA0012_mesh_files_cluster.sh
+./get_NACA0012_mesh_files_cluster.sh
+~~~~
+If you are a **new user on a CC cluster**, **you must configure git modules** by explicitly running the following on the cluster before proceeding:
 ~~~~
 chmod +x configure_git_submodules_cluster.sh
 ./configure_git_submodules_cluster.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,9 @@ If you are on another OS, the above script still serves as a nice guideline sinc
 Note that some features and tests from a recent pull request only work with Gmsh 4.6. See
 https://github.com/dougshidong/PHiLiP/pull/55
 
+## NACA0012 Mesh Files
+
+If you are running the code **on a local machine** (i.e. not on the cluster), you will need to download the [NACA0012 mesh files](https://drive.google.com/drive/folders/182JusbWV6NAA8ws1-TTg7M2GLc5jt6_r?usp=sharing) that are too large to store on GitHub by clicking the link, and place them in `tests/integration_tests_control_files/euler_integration/naca0012/`. **If you are running on the cluster, please see the instructions below.**
 
 ## deal.II
 
@@ -72,11 +75,11 @@ The deal.II library has been setup with the following options:
   Run  $ make info  to print a help message with a list of top level targets
 ~~~~
 
-## Installation of PHiLiP on Beluga cluster
+## Installation of PHiLiP on Compute Canada clusters
 
 This section is aimed at McGill's group who use the Compute Canada (CC) clusters.
 
-If you have just cloned the code onto the cluster, **you must copy the large NACA0012 mesh files** that cannot be stored on GitHub, this can be done by running the following:
+If you have just cloned the code onto the cluster, **you must copy the large NACA0012 mesh files** that cannot be stored on GitHub, this can be done by explicitly running the following:
 ~~~~
 chmod +x get_NACA0012_mesh_files_cluster.sh
 ./get_NACA0012_mesh_files_cluster.sh

--- a/get_NACA0012_mesh_files_cluster.sh
+++ b/get_NACA0012_mesh_files_cluster.sh
@@ -1,0 +1,10 @@
+# This must be ran at once whenever a clone of PHiLiP is made onto the cluster
+# DESCRIPTION: Copies the large mesh files for NACA0012 that cannot be stored on GitHub
+# NOTE: This is currently setup only for the Narval cluster
+PATH_TO_FILES=~/projects/def-nadaraja/Libraries/NACA0012MeshFiles
+FILENAMES=(naca0012_hopw_ref2.msh naca0012.msh)
+TARGET_DIR=tests/integration_tests_control_files/euler_integration/naca0012/
+
+for file in ${FILENAMES[@]}; do
+    cp ${PATH_TO_FILES}/${file} ${TARGET_DIR}
+done


### PR DESCRIPTION
This pull request is to update the installation instructions for the NACA0012 mesh files that must be downloaded externally, and provides a convenient solution for the cluster; see files changed. 