### PR TITLE
Bash Script for Downloading NACA0012 Mesh Files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,8 +19,7 @@ If you are running the code **on a local machine** (i.e. not on the cluster), yo
 1. `sudo apt install python3-pip` (if `pip` is not already installed)
 2. `pip install gdown` (if `gdown` is not already installed)
 3. If you receive a warning such as:
-   `WARNING: The script gdown is installed in '/home/parallels/.local/bin' which is not on PATH.
-    Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.`
+   `WARNING: The script gdown is installed in '/home/parallels/.local/bin' which is not on PATH.`
    then simply add the path by doing the following (modify accordingly):
    `echo export PATH=/home/parallels/.local/bin:$PATH >> ~/.bashrc`
    and resource:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,21 @@ https://github.com/dougshidong/PHiLiP/pull/55
 
 ## NACA0012 Mesh Files
 
-If you are running the code **on a local machine** (i.e. not on the cluster), you will need to download the [NACA0012 mesh files](https://drive.google.com/drive/folders/182JusbWV6NAA8ws1-TTg7M2GLc5jt6_r?usp=sharing) that are too large to store on GitHub by clicking the link, and place them in `tests/integration_tests_control_files/euler_integration/naca0012/`. **If you are running on the cluster, please see the instructions below.**
+**If you are running on the cluster, please see the instructions below in the Compute Canada section.**
+
+If you are running the code **on a local machine** (i.e. not on the cluster), you will need to download the [NACA0012 mesh files](https://drive.google.com/drive/folders/182JusbWV6NAA8ws1-TTg7M2GLc5jt6_r?usp=sharing) that are too large to store on GitHub by clicking the link, and place them in `tests/integration_tests_control_files/euler_integration/naca0012/`. To automate this process using `gdown`, do the following:
+1. `sudo apt install python3-pip` (if `pip` is not already installed)
+2. `pip install gdown` (if `gdown` is not already installed)
+3. If you receive a warning such as:
+   `WARNING: The script gdown is installed in '/home/parallels/.local/bin' which is not on PATH.
+    Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.`
+   then simply add the path by doing the following (modify accordingly):
+   `echo export PATH=/home/parallels/.local/bin:$PATH >> ~/.bashrc`
+   and resource:
+   `source ~/.bashrc`
+4. Then run the following bash script inside the `PHiLiP` directory:
+   `chmod +x get_NACA0012_mesh_files_local.sh`
+   `./get_NACA0012_mesh_files_local.sh`
 
 ## deal.II
 

--- a/get_NACA0012_mesh_files_local.sh
+++ b/get_NACA0012_mesh_files_local.sh
@@ -1,0 +1,10 @@
+TARGET_DIR=tests/integration_tests_control_files/euler_integration/naca0012/
+# get files from GoogleDrive using gdown
+gdown --id 1rzjT9DH4Cpe92SRTMig9aAKQNbDlQG5c # naca0012_hopw_ref0.msh
+gdown --id 1c0HUhoTR-ZFE_uy-rtV3ObMBsSlyvCpI # naca0012_hopw_ref1.msh
+gdown --id 1n5g3KOYJgsnzEtZIhPujbKS5sN0ztYWE # naca0012_hopw_ref2.msh
+gdown --id 1Iv8qfwh_KCv9KDeOXlBhmCaPTNiPtjQG # naca0012_hopw_ref3.msh
+gdown --id 15Tt4ZEcZye0Q-P2ynDy67ETqeuCgINjK # naca0012_hopw_ref4.msh
+gdown --id 1qxWlxhqK3_OrPUe9gcBpUMdny_dfrrBy # naca0012_hopw_ref5.msh
+# move files to appropriate directory
+mv naca0012_hopw_ref* ${TARGET_DIR}


### PR DESCRIPTION
This pull request closes #94 by automating the download of the mesh files from GoogleDrive using [gdown](https://github.com/wkentaro/gdown) -- this is intended to be used for installing on local machines only (i.e. not on the cluster as this has already been address there). 