### PR TITLE
Fix gmsh reader 2D cell rotation

### DIFF
--- a/get_NACA0012_mesh_files_local.sh
+++ b/get_NACA0012_mesh_files_local.sh
@@ -8,3 +8,7 @@ gdown 15Tt4ZEcZye0Q-P2ynDy67ETqeuCgINjK # naca0012_hopw_ref4.msh
 gdown 1qxWlxhqK3_OrPUe9gcBpUMdny_dfrrBy # naca0012_hopw_ref5.msh
 # move files to appropriate directory
 mv naca0012_hopw_ref* ${TARGET_DIR}
+
+TARGET_DIR=tests/unit_tests/grid/gmsh_reader/
+gdown 1HQAoa_dS8U91r0oPPuo1NN9ozXOnjymj # airfoil.msh
+mv airfoil.msh ${TARGET_DIR}

--- a/src/mesh/gmsh_reader.cpp
+++ b/src/mesh/gmsh_reader.cpp
@@ -77,6 +77,9 @@ void rotate_indices(std::vector<unsigned int> &numbers, const unsigned int n_ind
         {
           // Rotate xy-plane
           // counter-clockwise
+          // 3 6 2           2 5 1
+          // 7 8 5  becomes  6 8 4
+          // 0 4 1           3 7 0
           case 'z':
             for (unsigned int iz = 0; iz < ((dim > 2) ? n : 1); ++iz)
               for (unsigned int j = 0; j < n; ++j)
@@ -88,12 +91,29 @@ void rotate_indices(std::vector<unsigned int> &numbers, const unsigned int n_ind
             break;
           // Rotate xy-plane
           // clockwise
+          // 3 6 2           0 7 3
+          // 7 8 5  becomes  4 8 6
+          // 0 4 1           1 5 2
           case 'Z':
             for (unsigned int iz = 0; iz < ((dim > 2) ? n : 1); ++iz)
               for (unsigned int iy = 0; iy < n; ++iy)
                 for (unsigned int ix = 0; ix < n; ++ix)
                   {
                     unsigned int k = n * ix - iy + n - 1 + n * n * iz;
+                    numbers[k]     = l++;
+                  }
+            break;
+          // Change Z normal
+          // Instead of 
+          // 3 6 2           1 5 2
+          // 7 8 5  becomes  4 8 6
+          // 0 4 1           0 7 3
+          case '3':
+            for (unsigned int iz = 0; iz < ((dim > 2) ? n : 1); ++iz)
+              for (unsigned int iy = 0; iy < n; ++iy)
+                for (unsigned int ix = 0; ix < n; ++ix)
+                  {
+                    unsigned int k = iy + n * ix + n * n * iz; // transpose x and y indices
                     numbers[k]     = l++;
                   }
             break;
@@ -338,7 +358,14 @@ unsigned int gmsh_cell_type_to_order(unsigned int cell_type)
     } else if ( (cell_type == MSH_PNT) ) {
         cell_order = 0;
     } else {
-        //AssertThrow(false, dealii::ExcGmshUnsupportedGeometry(cell_type));
+        std::cout << "Invalid element type read from GMSH " << cell_type << ". "
+                  << "\n Valid element types are:"
+                  << "\n " << MSH_PNT
+                  << "\n " << MSH_LIN_2 << " " << MSH_LIN_3 << " " << MSH_LIN_4 << " " << MSH_LIN_5 << " " << MSH_LIN_6 << " " << MSH_LIN_7 << " " << MSH_LIN_8 << " " << MSH_LIN_9
+                  << "\n " << MSH_QUA_4 << " " << MSH_QUA_9 << " " << MSH_QUA_16 << " " << MSH_QUA_25 << " " << MSH_QUA_36 << " " << MSH_QUA_49 << " " << MSH_QUA_64 << " " << MSH_QUA_81
+                  << "\n " << MSH_HEX_8 <<  " " << MSH_HEX_27 << " " << MSH_HEX_64 << " " << MSH_HEX_125 << " " << MSH_HEX_216 << " " << MSH_HEX_343 << " " << MSH_HEX_512 << " " << MSH_HEX_729
+                  << std::endl;
+        std::abort();
     }
 
     return cell_order;
@@ -629,6 +656,56 @@ void fe_q_node_number(const unsigned int index,
     j = index;
     k = index;
 }
+
+template <int dim, int spacedim>
+bool get_new_rotated_indices(const dealii::CellAccessor<dim, spacedim>& cell,
+                             const std::vector<dealii::Point<spacedim>>& all_vertices,
+                             const std::vector<unsigned int>& deal_h2l,
+                             const std::vector<unsigned int>& rotate_z90degree,
+                             std::vector<unsigned int>& high_order_vertices_id)
+{
+
+    const unsigned int n_vertices = cell.n_vertices();
+    for (int zr = 0; zr < 4; ++zr) {
+
+        std::vector<char> matching(n_vertices);
+
+        for (unsigned int i_vertex=0; i_vertex < n_vertices; ++i_vertex) {
+
+            const unsigned int base_index = i_vertex;
+            const unsigned int lexicographic_index = deal_h2l[base_index];
+
+            const unsigned int vertex_id = high_order_vertices_id[lexicographic_index];
+            const dealii::Point<dim,double> high_order_vertex = all_vertices[vertex_id];
+
+            bool found = false;
+            for (unsigned int i=0; i < n_vertices; ++i) {
+                if (cell.vertex(i) == high_order_vertex) {
+                    found = true;
+                }
+            }
+            if (!found) {
+                std::cout << "Wrong cell... High order nodes do not match the cell's vertices." << std::endl;
+                std::abort();
+            }
+
+            matching[i_vertex] = (high_order_vertex == cell.vertex(i_vertex)) ? 'T' : 'F';
+        }
+
+        bool all_matching = true;
+        for (unsigned int i=0; i < n_vertices; ++i) {
+            if (matching[i] == 'F') all_matching = false;
+        }
+        if (all_matching) return true;
+
+        const auto high_order_vertices_id_temp = high_order_vertices_id;
+        for (unsigned int i=0; i<high_order_vertices_id.size(); ++i) {
+            high_order_vertices_id[i] = high_order_vertices_id_temp[rotate_z90degree[i]];
+        }
+    }
+    return false;
+}
+
 
 template <int dim, int spacedim>
 std::shared_ptr< HighOrderGrid<dim, double> >
@@ -936,7 +1013,7 @@ read_gmsh(std::string filename, int requested_grid_order)
     // AssertThrow(p1_cells.size() > 0, dealii::ExcGmshNoCellInformation());
   
     // do some clean-up on vertices...
-    auto all_vertices = vertices;
+    const std::vector<dealii::Point<spacedim>> all_vertices = vertices;
     dealii::GridTools::delete_unused_vertices(vertices, p1_cells, subcelldata);
     // ... and p1_cells
     if (dim == spacedim) {
@@ -1010,6 +1087,9 @@ read_gmsh(std::string filename, int requested_grid_order)
     //              << " maps to global id " 
     //              << " vertices high_order_vertices_id[i] << " point " << all_vertices[high_order_vertices_id[i]] << std::endl;
     //}
+    std::vector<unsigned int> rotate_z90degree;
+    rotate_indices<dim>(rotate_z90degree, grid_order+1, 'Z');
+
     for (const auto &cell : high_order_grid->dof_handler_grid.active_cell_iterators()) {
         if (cell->is_locally_owned()) {
             auto &high_order_vertices_id = high_order_cells[icell].vertices;
@@ -1017,18 +1097,12 @@ read_gmsh(std::string filename, int requested_grid_order)
             //for (unsigned int i=0; i<high_order_vertices_id.size(); ++i) {
             //    std::cout << " I " << high_order_vertices_id[i] << " point " << all_vertices[high_order_vertices_id[i]] << std::endl;
             //}
-            cell->get_dof_indices(dof_indices);
 
             //std::cout << " cell " << icell << " with vertices: " << std::endl;
             //for (unsigned int i=0; i < cell->n_vertices(); ++i) {
             //    std::cout << cell->vertex(i) << std::endl;
             //}
             //std::cout << " highordercell with vertices: " << std::endl;
-
-            std::vector<unsigned int> rotate_z90degree;
-            rotate_indices<dim>(rotate_z90degree, grid_order+1, 'Z');
-
-            bool good_rotation = false;
 
             auto high_order_vertices_id_lexico = high_order_vertices_id;
             for (unsigned int ihierachic=0; ihierachic<high_order_vertices_id.size(); ++ihierachic) {
@@ -1038,58 +1112,27 @@ read_gmsh(std::string filename, int requested_grid_order)
 
             //auto high_order_vertices_id_rotated = high_order_cells[icell].vertices;
             auto high_order_vertices_id_rotated = high_order_vertices_id_lexico;
-            for (int zr = 0; zr < 4; ++zr) {
-                
-                std::vector<int> matching(cell->n_vertices());
-                for (unsigned int i_vertex=0; i_vertex < cell->n_vertices(); ++i_vertex) {
+            bool good_rotation = get_new_rotated_indices(*cell, all_vertices, deal_h2l, rotate_z90degree, high_order_vertices_id_rotated);
+            if (!good_rotation) {
+                //std::cout << "Couldn't find rotation... Flipping Z axis and doing it again" << std::endl;
 
-                    const unsigned int base_index = i_vertex;
-                    const unsigned int lexicographic_index = deal_h2l[base_index];
-
-                    //const unsigned int gmsh_hierarchical_index = gmsh_l2h[lexicographic_index];
-                    //const unsigned int vertex_id = high_order_vertices_id_rotated[gmsh_hierarchical_index];
-                    const unsigned int vertex_id = high_order_vertices_id_rotated[lexicographic_index];
-                    const dealii::Point<dim,double> high_order_vertex = all_vertices[vertex_id];
-                    //std::cout << high_order_vertex << std::endl;
-
-                    bool found = false;
-                    for (unsigned int i=0; i < cell->n_vertices(); ++i) {
-                        if (cell->vertex(i) == high_order_vertex) {
-                            //std::cout << " cell vertex " << i << " matches HO vertex " << i_vertex << std::endl;
-                            found = true;
-                        }
-                    }
-                    if (!found) {
-                        std::cout << "Wrong cell... High order nodes do not match the cell's vertices." << std::endl;
-                        std::abort();
-                    }
-
-                    matching[i_vertex] = (high_order_vertex == cell->vertex(i_vertex)) ? 0 : 1;
-                }
-
-                bool all_matching = true;
-                for (unsigned int i=0; i < cell->n_vertices(); ++i) {
-                    if (matching[i] == 1) all_matching = false;
-                }
-                good_rotation = all_matching;
-                if (good_rotation) {
-                    //std::cout << "Found rotation cell..." << std::endl;
-                    break;
-                }
-
-                //std::cout << "Rotating indices " << std::endl;
-                high_order_vertices_id = high_order_vertices_id_rotated;
-                for (unsigned int i=0; i<high_order_vertices_id.size(); ++i) {
-                    high_order_vertices_id_rotated[i] = high_order_vertices_id[rotate_z90degree[i]];
+                // Flip Z-axis and do above again
+                std::vector<unsigned int> flipZ;
+                rotate_indices<dim>(flipZ, grid_order+1, '3');
+                auto high_order_vertices_id_copy = high_order_vertices_id_rotated;
+                for (unsigned int i=0; i<high_order_vertices_id_rotated.size(); ++i) {
+                    high_order_vertices_id_rotated[i] = high_order_vertices_id_copy[flipZ[i]];
                 }
             }
+            good_rotation = get_new_rotated_indices(*cell, all_vertices, deal_h2l, rotate_z90degree, high_order_vertices_id_rotated);
             if (!good_rotation) {
-                std::cout << "Couldn't find rotation..." << std::endl;
+                std::cout << "Couldn't find rotation after flipping either... Aborting..." << std::endl;
                 std::abort();
-            } 
+            }
 
 
 
+            cell->get_dof_indices(dof_indices);
             for (unsigned int i_vertex = 0; i_vertex < high_order_vertices_id.size(); ++i_vertex) {
 
                 const unsigned int base_index = i_vertex;

--- a/src/mesh/gmsh_reader.cpp
+++ b/src/mesh/gmsh_reader.cpp
@@ -685,7 +685,7 @@ bool get_new_rotated_indices(const dealii::CellAccessor<dim, spacedim>& cell,
                 }
             }
             if (!found) {
-                std::cout << "Wrong cell... High order nodes do not match the cell's vertices." << std::endl;
+                std::cout << "Wrong cell... High-order nodes do not match the cell's vertices." << std::endl;
                 std::abort();
             }
 

--- a/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
+++ b/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
@@ -45,13 +45,32 @@ foreach(dim RANGE 2 3)
         DEAL_II_SETUP_TARGET(${TEST_TARGET})
     endif()
 
-    add_test(
-      NAME ${TEST_TARGET}
-      COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET}
-      WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
-    )
-
     unset(TEST_TARGET)
 
 endforeach()
+
+foreach(dim RANGE 2 3)
+    add_test(
+      NAME ${dim}D_GMSH_READER_SQUARE
+      COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/${dim}D_GMSH_READER --input=${dim}D_square.msh
+      WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+    )
+endforeach()
+
+set (filename "airfoil.msh")
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
+  message(SEND_ERROR
+"Missing NACA0012 files named ${filename}. Please download them from
+    https://drive.google.com/drive/folders/1EeN4ooMK2awre2O_WBWJNMyO4FGDX_PN?usp=sharing
+and place them in
+      ${CMAKE_CURRENT_SOURCE_DIR}"
+      )
+endif()
+
+configure_file(${filename} ${filename} COPYONLY)
+add_test(
+  NAME 2D_GMSH_READER_NACA0012
+  COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/2D_GMSH_READER --input=${filename}
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
 

--- a/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
+++ b/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
@@ -63,7 +63,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing NACA0012 files named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1EeN4ooMK2awre2O_WBWJNMyO4FGDX_PN?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_NACA0012_mesh_files_local.sh"
       )
 endif()
 

--- a/tests/unit_tests/grid/gmsh_reader/gmsh_reader.cpp
+++ b/tests/unit_tests/grid/gmsh_reader/gmsh_reader.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+
 #include <deal.II/grid/grid_out.h>
 #include "mesh/gmsh_reader.hpp"
 
@@ -12,7 +14,20 @@ int main (int argc, char * argv[])
 
     using namespace PHiLiP;
 
-    std::string filename = std::to_string(dim) + "D_square.msh";
+    std::string filename;
+    for (int i = 1; i < argc; i++) {
+        std::string s(argv[i]);
+        if (s.rfind("--input=", 0) == 0) {
+            filename = s.substr(std::string("--input=").length());
+            std::ifstream f(filename);
+            std::cout << "File " << filename;
+            if (f.good()) std::cout << " exists" << std::endl;
+            else std::cout << " not found" << std::endl;
+            }
+        else {
+            std::cout << "Unknown: " << s << std::endl;
+        }
+    }
 
     std::shared_ptr< HighOrderGrid<dim, double> > high_order_grid = read_gmsh <dim, dim> (filename);
 


### PR DESCRIPTION
Fix issue brought up by @MayaTatarelli not being able to read .msh file.

Attached is the .msh file, the .geo used to generate it (requires Gmsh with OpenCascade), and the resulting output when run with the previous code.

More notatbly, the output "Couldn't find rotation..." shows that we are not able to read the element vertices due to improper rotations

[airfoil.zip](https://github.com/dougshidong/PHiLiP/files/8386833/airfoil.zip)

1. This issue has been fixed by including the additional cell vertices permutation (left-hand rule ordering or flipping the Z-axis direction).
2. The .msh that exposed the issue has been added to the unit test suite.

@kit71717 Calvin, you might want to review this PR since you are likely doing something similar in 3D.