### PR TITLE
Mesh directory for tests

### DIFF
--- a/get_NACA0012_mesh_files_cluster.sh
+++ b/get_NACA0012_mesh_files_cluster.sh
@@ -3,7 +3,7 @@
 # NOTE: This is currently setup only for the Narval cluster
 PATH_TO_FILES=~/projects/def-nadaraja/Libraries/NACA0012MeshFiles
 FILENAMES=(naca0012_hopw_ref5.msh naca0012_hopw_ref4.msh naca0012_hopw_ref3.msh naca0012_hopw_ref2.msh naca0012_hopw_ref1.msh naca0012_hopw_ref0.msh naca0012.msh)
-TARGET_DIR=tests/integration_tests_control_files/euler_integration/naca0012/
+TARGET_DIR=tests/meshes/
 
 for file in ${FILENAMES[@]}; do
     cp ${PATH_TO_FILES}/${file} ${TARGET_DIR}

--- a/get_NACA0012_mesh_files_local.sh
+++ b/get_NACA0012_mesh_files_local.sh
@@ -1,4 +1,4 @@
-TARGET_DIR=tests/integration_tests_control_files/euler_integration/naca0012/
+TARGET_DIR=tests/meshes/
 # get files from GoogleDrive using gdown
 gdown 1rzjT9DH4Cpe92SRTMig9aAKQNbDlQG5c # naca0012_hopw_ref0.msh
 gdown 1c0HUhoTR-ZFE_uy-rtV3ObMBsSlyvCpI # naca0012_hopw_ref1.msh

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(unit_tests)
 add_subdirectory(integration_tests_control_files)
+add_subdirectory(meshes)

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_subsonic_05_200.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_subsonic_05_200.prm
@@ -107,7 +107,7 @@ subsection flow_solver
   set steady_state = true
   set steady_state_polynomial_ramping = true
   subsection grid
-    set input_mesh_filename = naca0012_hopw_ref2
+    set input_mesh_filename = ../../../meshes/naca0012_hopw_ref2
   end
 end
 

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_transonic_08_125.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_transonic_08_125.prm
@@ -107,6 +107,6 @@ subsection flow_solver
   set steady_state = true
   set steady_state_polynomial_ramping = true
   subsection grid
-    set input_mesh_filename = naca0012_hopw_ref2
+    set input_mesh_filename = ../../../meshes/naca0012_hopw_ref2
   end
 end

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_navier_stokes_naca0012_subsonic_05_200.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_navier_stokes_naca0012_subsonic_05_200.prm
@@ -114,7 +114,7 @@ end
 
 subsection flow_solver
   subsection grid
-    set input_mesh_filename = naca0012_hopw_ref5
+    set input_mesh_filename = ../../../meshes/naca0012_hopw_ref5
   end
 end
 

--- a/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
@@ -35,9 +35,6 @@ and place them in
       ${CMAKE_CURRENT_SOURCE_DIR}"
       )
 endif()
-configure_file(naca0012_hopw_ref2.msh naca0012.msh COPYONLY)
-configure_file(naca0012_hopw_ref2.msh naca0012_hopw_ref2.msh COPYONLY)
-configure_file(naca0012_hopw_ref5.msh naca0012_hopw_ref5.msh COPYONLY)
 
 #configure_file(naca0012.geo naca0012.geo COPYONLY)
 #configure_file(naca0012_noTE.geo naca0012_noTE.geo COPYONLY)

--- a/tests/integration_tests_control_files/euler_integration/naca0012/inviscid_transonic_steady_state_naca0012.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/inviscid_transonic_steady_state_naca0012.prm
@@ -65,7 +65,7 @@ subsection flow_solver
   set poly_degree = 0
   set steady_state = true
   subsection grid
-    set input_mesh_filename = naca0012_hopw_ref2
+    set input_mesh_filename = ../../../meshes/naca0012_hopw_ref2
   end
 end
 

--- a/tests/meshes/CMakeLists.txt
+++ b/tests/meshes/CMakeLists.txt
@@ -1,0 +1,7 @@
+configure_file(naca0012_hopw_ref2.msh naca0012.msh COPYONLY)
+configure_file(naca0012_hopw_ref0.msh naca0012_hopw_ref0.msh COPYONLY)
+configure_file(naca0012_hopw_ref1.msh naca0012_hopw_ref1.msh COPYONLY)
+configure_file(naca0012_hopw_ref2.msh naca0012_hopw_ref2.msh COPYONLY)
+configure_file(naca0012_hopw_ref3.msh naca0012_hopw_ref3.msh COPYONLY)
+configure_file(naca0012_hopw_ref4.msh naca0012_hopw_ref4.msh COPYONLY)
+configure_file(naca0012_hopw_ref5.msh naca0012_hopw_ref5.msh COPYONLY)


### PR DESCRIPTION
PR to move the meshes to a non-test specific directory. This will be useful for @donovan97 's integration tests that use the NACA0012 meshes to avoid having to copy them to an additional integration test directory (where his test is). 