### PR TITLE
Fixing cmake error for naca mesh files

### DIFF
--- a/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
@@ -27,7 +27,7 @@ add_test(
 #)
 
 set (filename "naca0012_hopw_ref2.msh")
-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../meshes/${filename})
   message(SEND_ERROR
 "Missing NACA0012 files named ${filename}. Please download them from
     https://drive.google.com/drive/folders/182JusbWV6NAA8ws1-TTg7M2GLc5jt6_r?usp=sharing


### PR DESCRIPTION
PR to fix the error that is encountered when trying to run `cmake` in a new PHiLiP directory that has just been cloned. 

This was not caught in PR #160 since a copy of the mesh files was present in original directory (`tests/integration_tests/euler_integration/naca0012/`). 