### PR TITLE
Setting recursive submodule to true in git config.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,6 +109,7 @@ git submodule update
 git config --global http.proxy ""
 git pull --recurse-submodules
 git submodule update --recursive
+git config submodule.recurse true
 ~~~~
 For Beluga, the deal.II library is already installed in `/project/rrg-nadaraja-ac/Libraries/dealii/install`; install paths for other clusters are included in `job_compile_PHiLiP.sh`. The required modules were installed by Bart Oldeman from Compute Canada's team through modules. Therefore, simply put the following line in your .bashrc and source it.
 ~~~~

--- a/configure_git_submodules_cluster.sh
+++ b/configure_git_submodules_cluster.sh
@@ -3,3 +3,4 @@ git submodule update
 git config --global http.proxy ""
 git pull --recurse-submodules
 git submodule update --recursive
+git config submodule.recurse true

--- a/doc/install_ubuntu2004_VM.sh
+++ b/doc/install_ubuntu2004_VM.sh
@@ -158,6 +158,7 @@ mkdir -p Codes
     git config submodule.recurse true ;\
     
     # Get mesh files of NACA 0012. Note: Run get_NACA0012_mesh_files_cluster.sh to get files on the cluster.
+    # If not already installed, gdown can be installed as explained in INSTALL.md.  
     sh get_NACA0012_mesh_files_local.sh ;\
 
 	# Release build with all the optimization flags

--- a/doc/install_ubuntu2004_VM.sh
+++ b/doc/install_ubuntu2004_VM.sh
@@ -155,6 +155,11 @@ mkdir -p Codes
 	cd $Codes/PHiLiP ;\
 	git checkout master ;\
 	git remote add upstream https://github.com/dougshidong/PHiLiP.git ;\
+    git config submodule.recurse true ;\
+    
+    # Get mesh files of NACA 0012. Note: Run get_NACA0012_mesh_files_cluster.sh to get files on the cluster.
+    sh get_NACA0012_mesh_files_local.sh ;\
+
 	# Release build with all the optimization flags
 	mkdir -p build_release && cd build_release ;\
 	# MPI_MAX is the number of cores to use by default for tests with MPI

--- a/doc/install_ubuntu2004_VM.sh
+++ b/doc/install_ubuntu2004_VM.sh
@@ -163,7 +163,8 @@ mkdir -p Codes
     git config submodule.recurse true ;\
     
     # Get mesh files of NACA 0012. Note: Run get_NACA0012_mesh_files_cluster.sh to get files on the cluster.
-    # If not already installed, gdown can be installed as explained in INSTALL.md.  
+    # If not already installed, gdown can be installed as explained in INSTALL.md. 
+    chmod +x get_NACA0012_mesh_files_local.sh
     sh get_NACA0012_mesh_files_local.sh ;\
 
 	# Release build with all the optimization flags

--- a/doc/install_ubuntu2004_VM.sh
+++ b/doc/install_ubuntu2004_VM.sh
@@ -21,6 +21,11 @@ sudo apt install -y \
 	texlive \
 	liboce-ocaf-lite-dev
 
+### Install pip and gdown
+sudo apt install python3-pip
+pip install gdown
+# Note: If you receive a warning such as: WARNING: The script gdown is installed in '/home/parallels/.local/bin' which is not on PATH, add the path as explained in INSTALL.md.
+
 ### Update gmsh to latest version
 pip install --upgrade gmsh
 


### PR DESCRIPTION
And after updating the master and merging submodule with Eigen, checking out into a local branch (created before adding Eigen) gives a message `warning: unable to rmdir 'submodules/eigen': Directory not empty`. Apparently, git checkout might not take care of the submodules (as discussed in this [link](https://stackoverflow.com/questions/45215094/git-bash-giving-error-of-warning-unable-to-rmdir)). This warning can be avoided by setting submodule recurse to true in git config.

This pull request is aimed at setting recursive submodules to true in git config and updating the documentation for installing PHiLiP. 