### PR TITLE
Higher Order VTK Output based on the maximum polynomial degree

### DIFF
--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -1749,7 +1749,7 @@ public:
 
 
 template <int dim, typename real, typename MeshType>
-void DGBase<dim,real,MeshType>::output_face_results_vtk (const unsigned int cycle)// const
+void DGBase<dim,real,MeshType>::output_face_results_vtk (const unsigned int cycle, const double current_time)// const
 {
 
     DataOutEulerFaces<dim, dealii::DoFHandler<dim>> data_out;
@@ -1836,7 +1836,7 @@ void DGBase<dim,real,MeshType>::output_face_results_vtk (const unsigned int cycl
     data_out.build_patches(mapping, n_subdivisions);
     //const bool write_higher_order_cells = (dim>1 && max_degree > 1) ? true : false;
     const bool write_higher_order_cells = false;//(dim>1 && grid_degree > 1) ? true : false;
-    dealii::DataOutBase::VtkFlags vtkflags(0.0,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);
+    dealii::DataOutBase::VtkFlags vtkflags(current_time,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);
     data_out.set_flags(vtkflags);
 
     const int iproc = dealii::Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -1867,10 +1867,10 @@ void DGBase<dim,real,MeshType>::output_face_results_vtk (const unsigned int cycl
 #endif
 
 template <int dim, typename real, typename MeshType>
-void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle)// const
+void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle, const double current_time)// const
 {
 #if PHILIP_DIM>1
-    output_face_results_vtk (cycle);
+    output_face_results_vtk (cycle, current_time);
 #endif
 
     dealii::DataOut<dim, dealii::DoFHandler<dim>> data_out;
@@ -1946,14 +1946,11 @@ void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle)// 
     //typename dealii::DataOut<dim>::CurvedCellRegion curved = dealii::DataOut<dim>::CurvedCellRegion::no_curved_cells;
 
     const dealii::Mapping<dim> &mapping = (*(high_order_grid->mapping_fe_field));
-    const int grid_degree = high_order_grid->max_degree;
-    //const int n_subdivisions = max_degree+1;//+30; // if write_higher_order_cells, n_subdivisions represents the order of the cell
-    //const int n_subdivisions = 1;//+30; // if write_higher_order_cells, n_subdivisions represents the order of the cell
-    const int n_subdivisions = grid_degree;
+    const unsigned int grid_degree = high_order_grid->max_degree;
+    const int n_subdivisions = std::max(grid_degree,get_max_fe_degree());
     data_out.build_patches(mapping, n_subdivisions, curved);
-    //const bool write_higher_order_cells = (dim>1 && max_degree > 1) ? true : false;
-    const bool write_higher_order_cells = (dim>1 && grid_degree > 1) ? true : false;
-    dealii::DataOutBase::VtkFlags vtkflags(0.0,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);
+    const bool write_higher_order_cells = (n_subdivisions>1) ? true : false;
+    dealii::DataOutBase::VtkFlags vtkflags(current_time,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);
     data_out.set_flags(vtkflags);
 
     const int iproc = dealii::Utilities::MPI::this_mpi_process(mpi_communicator);

--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -1873,6 +1873,7 @@ void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle, co
     output_face_results_vtk (cycle, current_time);
 #endif
 
+    const bool enable_higher_order_vtk_output = this->all_parameters->enable_higher_order_vtk_output;
     dealii::DataOut<dim, dealii::DoFHandler<dim>> data_out;
 
     data_out.attach_dof_handler (dof_handler);
@@ -1947,7 +1948,8 @@ void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle, co
 
     const dealii::Mapping<dim> &mapping = (*(high_order_grid->mapping_fe_field));
     const unsigned int grid_degree = high_order_grid->max_degree;
-    const int n_subdivisions = std::max(grid_degree,get_max_fe_degree());
+    // If higher-order vtk output is not enabled, passing 0 will be interpreted as DataOutInterface::default_subdivisions
+    const int n_subdivisions = (enable_higher_order_vtk_output) ? std::max(grid_degree,get_max_fe_degree()) : 0;
     data_out.build_patches(mapping, n_subdivisions, curved);
     const bool write_higher_order_cells = (n_subdivisions>1) ? true : false;
     dealii::DataOutBase::VtkFlags vtkflags(current_time,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);

--- a/src/dg/dg.h
+++ b/src/dg/dg.h
@@ -432,9 +432,8 @@ public:
 
     void initialize_manufactured_solution (); ///< Virtual function defined in DG
 
-    void output_results_vtk (const unsigned int ith_grid); ///< Output solution
-    void output_face_results_vtk (const unsigned int ith_grid); ///< Output Euler face solution
-    void output_paraview_results (std::string filename); ///< Outputs a paraview file to view the solution
+    void output_results_vtk (const unsigned int cycle, const double current_time=0.0); ///< Output solution
+    void output_face_results_vtk (const unsigned int cycle, const double current_time=0.0); ///< Output Euler face solution
 
     bool update_artificial_diss;
     /// Main loop of the DG class.

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -463,7 +463,7 @@ int FlowSolver<dim,nstate>::run() const
                 if (is_output_iteration) {
                     pcout << "  ... Writing vtk solution file ..." << std::endl;
                     const int file_number = ode_solver->current_iteration / ode_param.output_solution_every_x_steps;
-                    dg->output_results_vtk(file_number);
+                    dg->output_results_vtk(file_number,ode_solver->current_time);
                 }
             } else if(ode_param.output_solution_every_dt_time_intervals > 0.0) {
                 const bool is_output_time = ((ode_solver->current_time <= ode_solver->current_desired_time_for_output_solution_every_dt_time_intervals) && 
@@ -471,7 +471,7 @@ int FlowSolver<dim,nstate>::run() const
                 if (is_output_time) {
                     pcout << "  ... Writing vtk solution file ..." << std::endl;
                     const int file_number = ode_solver->current_desired_time_for_output_solution_every_dt_time_intervals / ode_param.output_solution_every_dt_time_intervals;
-                    dg->output_results_vtk(file_number);
+                    dg->output_results_vtk(file_number,ode_solver->current_time);
                     ode_solver->current_desired_time_for_output_solution_every_dt_time_intervals += ode_param.output_solution_every_dt_time_intervals;
                 }
             }

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -212,6 +212,14 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
                       "Name of directory for writing solution vtk files. Current directory by default.");
 
+    prm.declare_entry("enable_higher_order_vtk_output", "false",
+                      dealii::Patterns::Bool(),
+                      "Enable writing of higher-order vtk files."
+                      "False by default. If modified to true,"
+                      "number of subdivisions will be chosen"
+                      "according to the max of grid_degree"
+                      "and poly_degree.");
+
     Parameters::LinearSolverParam::declare_parameters (prm);
     Parameters::ManufacturedConvergenceStudyParam::declare_parameters (prm);
     Parameters::ODESolverParam::declare_parameters (prm);
@@ -369,6 +377,7 @@ void AllParameters::parse_parameters (dealii::ParameterHandler &prm)
     if (flux_reconstruction_aux_string == "k10Thousand") flux_reconstruction_aux_type = k10Thousand;
 
     solution_vtk_files_directory_name = prm.get("solution_vtk_files_directory_name");
+    enable_higher_order_vtk_output = prm.get_bool("enable_higher_order_vtk_output");
 
     pcout << "Parsing linear solver subsection..." << std::endl;
     linear_solver_param.parse_parameters (prm);

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -219,6 +219,9 @@ public:
     /// Name of directory for writing solution vtk files
     std::string solution_vtk_files_directory_name;
 
+    /// Enable writing of higher-order vtk results
+    bool enable_higher_order_vtk_output;
+
     /// Declare parameters that can be set as inputs and set up the default options
     /** This subroutine should call the sub-parameter classes static declare_parameters()
       * such that each sub-parameter class is responsible to declare their own parameters.


### PR DESCRIPTION
This PR enables higher-order VTK output for use with ParaView.

Specifically, the function `DGBase::output_results_vtk()`  has been modified to select the number of subdivisions from the maximum of `grid_degree` and `poly_degree`, which allows higher-order results to be written even if the grid is straight. 

A parameter, `enable_higher_order_vtk_output`, is added to toggle whether higher-order results are written, which is false by default. In some cases, it may be sufficient to visualize only (bi/tri)linear interpolations, such as if the grid is fine. As well, not all vtk visualization programs support higher-order Lagrange elements. ParaView is able to (see [this deal.ii wiki page ](https://github.com/dealii/dealii/wiki/Notes-on-visualizing-high-order-output)). From my testing, VisIt cannot handle higher-order solutions, and is unable to interpret the vtk files. I'm unsure about other vtk programs.

Additionally, I have added an optional parameter to `DGBase::output_results_vtk()`, `current_time`. This can be used to add the simulation time to the visualization. If `current_time` isn't passed, the time is written as `0.0`, consistent with previous behaviour. On ParaView, select Filters->Annotate Global Data to show the current time.

To demonstrate the new behaviour, I've attached a visualization of `MPI_VISCOUS_TAYLOR_GREEN_VORTEX_ENERGY_CHECK_LONG` after 400 iterations, both with and without higher-order output.
![TGV_withHigherOrder](https://user-images.githubusercontent.com/94074298/206259788-e26d6df6-c952-4949-8a4a-66b91e89aa3b.png)
![TGV_noHigherOrder](https://user-images.githubusercontent.com/94074298/206259789-9cad8fc2-285e-491a-a10e-469ddad68494.png)
