### PR TITLE
Bugfix for writing higher-order data in 1D

### DIFF
--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -2043,7 +2043,7 @@ void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle, co
     // If higher-order vtk output is not enabled, passing 0 will be interpreted as DataOutInterface::default_subdivisions
     const int n_subdivisions = (enable_higher_order_vtk_output) ? std::max(grid_degree,get_max_fe_degree()) : 0;
     data_out.build_patches(mapping, n_subdivisions, curved);
-    const bool write_higher_order_cells = (n_subdivisions>1) ? true : false;
+    const bool write_higher_order_cells = (n_subdivisions>1 && dim>1) ? true : false;
     dealii::DataOutBase::VtkFlags vtkflags(current_time,cycle,true,dealii::DataOutBase::VtkFlags::ZlibCompressionLevel::best_compression,write_higher_order_cells);
     data_out.set_flags(vtkflags);
 


### PR DESCRIPTION
The changes in PR #181 introduced a bug where higher-order 1D results would either crash paraview or produce obviously incorrect results. The change in this PR yields nice, smooth plot on paraview.

For future reference, here is how to plot higher-order 1D results:
- Use the parameter `enable_higher_order_vtk_output = true` (it is false by default)
- There's no need to increase `grid_degree` to match `poly_degree`. 
- Open in paraview and use the filter PlotOverLine.
- Paraview will automatically use the higher-order result. No need to set `nonlinear subdivision level`.

Before, 16 elements with p=7:
<img src="https://user-images.githubusercontent.com/94074298/224126367-f20dbf66-d970-4cb2-b8ae-bc1eb3ffde76.png" width=40% height=40%>
After:
<img src="https://user-images.githubusercontent.com/94074298/224126436-6c92f6a7-d95b-4434-8171-f09327a60438.png" width=40% height=40%>