### PR TITLE
Flow solver file output improvements

### DIFF
--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -1962,7 +1962,7 @@ template <int dim, typename real, typename MeshType>
 void DGBase<dim,real,MeshType>::output_results_vtk (const unsigned int cycle, const double current_time)// const
 {
 #if PHILIP_DIM>1
-    output_face_results_vtk (cycle, current_time);
+    if(this->all_parameters->output_face_results_vtk) output_face_results_vtk (cycle, current_time);
 #endif
 
     const bool enable_higher_order_vtk_output = this->all_parameters->enable_higher_order_vtk_output;

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -496,9 +496,6 @@ int FlowSolver<dim,nstate>::run() const
             // update time step in flow_solver_case
             flow_solver_case->set_time_step(time_step);
 
-            // update model variables
-            flow_solver_case->update_model_variables(dg);
-
             // advance solution
             ode_solver->step_in_time(time_step,false); // pseudotime==false
 

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -469,13 +469,22 @@ int FlowSolver<dim,nstate>::run() const
         pcout << "Timer starting. " << std::endl;
         dealii::Timer timer(this->mpi_communicator,false);
         timer.start();
-        while((ode_solver->current_time) < (final_time - 1E-13)) //comparing to 1E-13 to avoid taking an extra timestep
+        while(ode_solver->current_time < final_time)
         {
             if(flow_solver_param.adaptive_time_step == false) {
                 // reset time step to target if using a constant time step
                 time_step = flow_solver_case->get_constant_time_step(dg);// NOTE: add a test for restart with adaptive time step
                 flow_solver_case->set_time_step(time_step);
             }
+
+            if((ode_solver->current_time+time_step) > final_time) {
+                // decrease time step to finish exactly at specified final time
+                time_step = final_time - ode_solver->current_time;
+                flow_solver_case->set_time_step(time_step);
+            }
+
+            // update model variables
+            flow_solver_case->update_model_variables(dg);
 
             // advance solution
             ode_solver->step_in_time(time_step,false); // pseudotime==false

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -79,6 +79,7 @@ FlowSolver<dim, nstate>::FlowSolver(
         solution_transfer.deserialize(solution_no_ghost);
         dg->solution = solution_no_ghost; //< assignment
 #endif
+        pcout << "done." << std::endl;
     } else {
         // Initialize solution
         SetInitialCondition<dim,nstate,double>::set_initial_condition(flow_solver_case->initial_condition_function, dg, &all_param);
@@ -503,7 +504,6 @@ int FlowSolver<dim,nstate>::run() const
 
             // Compute the unsteady quantities, write to the dealii table, and output to file
             flow_solver_case->compute_unsteady_data_and_write_to_table(ode_solver->current_iteration, ode_solver->current_time, dg, unsteady_data_table);
-
             // update next time step
             if(flow_solver_param.adaptive_time_step == true) {
                 next_time_step = flow_solver_case->get_adaptive_time_step(dg);
@@ -519,14 +519,14 @@ int FlowSolver<dim,nstate>::run() const
                                                  ((ode_solver->current_time + next_time_step) > current_desired_time_for_output_restart_files_every_dt_time_intervals));
                     if (is_output_time) {
                         const unsigned int file_number = current_desired_time_for_output_restart_files_every_dt_time_intervals / flow_solver_param.output_restart_files_every_dt_time_intervals;
-                        output_restart_files(file_number, time_step, unsteady_data_table);
+                        output_restart_files(file_number, next_time_step, unsteady_data_table);
                         current_desired_time_for_output_restart_files_every_dt_time_intervals += flow_solver_param.output_restart_files_every_dt_time_intervals;
                     }
                 } else /*if (flow_solver_param.output_restart_files_every_x_steps > 0)*/ {
                     const bool is_output_iteration = (ode_solver->current_iteration % flow_solver_param.output_restart_files_every_x_steps == 0);
                     if (is_output_iteration) {
                         const unsigned int file_number = ode_solver->current_iteration / flow_solver_param.output_restart_files_every_x_steps;
-                        output_restart_files(file_number, time_step, unsteady_data_table);
+                        output_restart_files(file_number, next_time_step, unsteady_data_table);
                     }
                 }
             }

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -488,7 +488,7 @@ int FlowSolver<dim,nstate>::run() const
                 const double next_time = ode_solver->current_time + time_step;
                 const double desired_time = this->output_solution_fixed_times[index_of_current_desired_fixed_time_to_output_solution];
                 // // Check if current time is an output time
-                const bool is_output_time = ((ode_solver->current_time<desired_time) && (next_time>desired_time)); // make sure velocity field output logic is the same
+                const bool is_output_time = ((ode_solver->current_time<desired_time) && (next_time>desired_time));
                 if(is_output_time) time_step = desired_time - ode_solver->current_time;
             }
 
@@ -557,7 +557,7 @@ int FlowSolver<dim,nstate>::run() const
                 if(this->output_solution_at_exact_fixed_times) {
                     is_output_time = ode_solver->current_time == desired_time;
                 } else {
-                    is_output_time = ((ode_solver->current_time<=desired_time) && (next_time>desired_time)); // make sure velocity field output logic is the same
+                    is_output_time = ((ode_solver->current_time<=desired_time) && (next_time>desired_time));
                 }
                 if(is_output_time) {
                     pcout << "  ... Writing vtk solution file ..." << std::endl;

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -488,7 +488,7 @@ int FlowSolver<dim,nstate>::run() const
             } else if (this->output_solution_at_exact_fixed_times && (this->do_output_solution_at_fixed_times && (this->number_of_fixed_times_to_output_solution > 0))) { // change this to some parameter
                 const double next_time = ode_solver->current_time + time_step;
                 const double desired_time = this->output_solution_fixed_times[index_of_current_desired_fixed_time_to_output_solution];
-                // // Check if current time is an output time
+                // Check if current time is an output time
                 const bool is_output_time = ((ode_solver->current_time<desired_time) && (next_time>desired_time));
                 if(is_output_time) time_step = desired_time - ode_solver->current_time;
             }

--- a/src/flow_solver/flow_solver.h
+++ b/src/flow_solver/flow_solver.h
@@ -107,6 +107,7 @@ protected:
 
     const bool do_output_solution_at_fixed_times; ///< Flag for outputting solution at fixed times
     const unsigned int number_of_fixed_times_to_output_solution; ///< Number of fixed times to output the solution
+    const bool output_solution_at_exact_fixed_times;///< Flag for outputting the solution at exact fixed times by decreasing the time step on the fly
     
 public:
     /// Pointer to dg so it can be accessed externally.

--- a/src/flow_solver/flow_solver.h
+++ b/src/flow_solver/flow_solver.h
@@ -104,6 +104,9 @@ protected:
 
     /// Name of the reference copy of inputted parameters file; for restart purposes
     const std::string input_parameters_file_reference_copy_filename;
+
+    const bool do_output_solution_at_fixed_times; ///< Flag for outputting solution at fixed times
+    const unsigned int number_of_fixed_times_to_output_solution; ///< Number of fixed times to output the solution
     
 public:
     /// Pointer to dg so it can be accessed externally.
@@ -136,6 +139,9 @@ private:
     /** Currently implemented for steady state flows.
      */
     void perform_steady_state_mesh_adaptation() const;
+
+    /// Fixed times at which to output the solution
+    dealii::Table<1,double> output_solution_fixed_times;
 };
 
 } // FlowSolver namespace

--- a/src/flow_solver/flow_solver_cases/flow_solver_case_base.cpp
+++ b/src/flow_solver/flow_solver_cases/flow_solver_case_base.cpp
@@ -120,10 +120,10 @@ template <int dim, int nstate>
 double FlowSolverCaseBase<dim,nstate>::get_constant_time_step(std::shared_ptr<DGBase<dim,double>> /*dg*/) const
 {
     if(all_param.flow_solver_param.constant_time_step > 0.0) {
-        pcout << "Using constant time step in FlowSolver parameters." << std::endl;
+        // Using constant time step in FlowSolver parameters.
         return all_param.flow_solver_param.constant_time_step;
     } else {
-        pcout << "Using initial time step in ODE parameters." <<std::endl;
+        // Using initial time step in ODE parameters.
         return all_param.ode_solver_param.initial_time_step;
     }
 }

--- a/src/flow_solver/flow_solver_cases/periodic_turbulence.cpp
+++ b/src/flow_solver/flow_solver_cases/periodic_turbulence.cpp
@@ -29,6 +29,7 @@ PeriodicTurbulence<dim, nstate>::PeriodicTurbulence(const PHiLiP::Parameters::Al
         , output_velocity_field_at_fixed_times(this->all_param.flow_solver_param.output_velocity_field_at_fixed_times)
         , output_vorticity_magnitude_field_in_addition_to_velocity(this->all_param.flow_solver_param.output_vorticity_magnitude_field_in_addition_to_velocity)
         , output_flow_field_files_directory_name(this->all_param.flow_solver_param.output_flow_field_files_directory_name)
+        , output_solution_at_exact_fixed_times(this->all_param.ode_solver_param.output_solution_at_exact_fixed_times)
 {
     // Get the flow case type
     using FlowCaseEnum = Parameters::FlowSolverParam::FlowCaseType;
@@ -151,7 +152,7 @@ void PeriodicTurbulence<dim, nstate>::output_velocity_field(
     const unsigned int output_file_index,
     const double current_time) const
 {
-    this->pcout << "     ... Writting velocity field ... " << std::flush;
+    this->pcout << "  ... Writting velocity field ... " << std::flush;
 
     // NOTE: Same loop from read_values_from_file_and_project() in set_initial_condition.cpp
     
@@ -766,7 +767,13 @@ void PeriodicTurbulence<dim, nstate>::compute_unsteady_data_and_write_to_table(
         const double next_time = current_time + time_step;
         const double desired_time = this->output_velocity_field_times[this->index_of_current_desired_time_to_output_velocity_field];
         // Check if current time is an output time
-        if((current_time<=desired_time) && (next_time>desired_time)) {
+        bool is_output_time = false; // default initialization
+        if(this->output_solution_at_exact_fixed_times) {
+            is_output_time = current_time == desired_time;
+        } else {
+            is_output_time = ((current_time<=desired_time) && (next_time>desired_time));
+        }
+        if(is_output_time) {
             // Output velocity field for current index
             this->output_velocity_field(dg, this->index_of_current_desired_time_to_output_velocity_field, current_time);
             

--- a/src/flow_solver/flow_solver_cases/periodic_turbulence.cpp
+++ b/src/flow_solver/flow_solver_cases/periodic_turbulence.cpp
@@ -29,7 +29,6 @@ PeriodicTurbulence<dim, nstate>::PeriodicTurbulence(const PHiLiP::Parameters::Al
         , output_velocity_field_at_fixed_times(this->all_param.flow_solver_param.output_velocity_field_at_fixed_times)
         , output_vorticity_magnitude_field_in_addition_to_velocity(this->all_param.flow_solver_param.output_vorticity_magnitude_field_in_addition_to_velocity)
         , output_flow_field_files_directory_name(this->all_param.flow_solver_param.output_flow_field_files_directory_name)
-        , output_solution_files_at_velocity_field_output_times(this->all_param.flow_solver_param.output_solution_files_at_velocity_field_output_times)
 {
     // Get the flow case type
     using FlowCaseEnum = Parameters::FlowSolverParam::FlowCaseType;
@@ -770,9 +769,6 @@ void PeriodicTurbulence<dim, nstate>::compute_unsteady_data_and_write_to_table(
         if((current_time<=desired_time) && (next_time>desired_time)) {
             // Output velocity field for current index
             this->output_velocity_field(dg, this->index_of_current_desired_time_to_output_velocity_field, current_time);
-            
-            // Output solution files
-            if(output_solution_files_at_velocity_field_output_times) dg->output_results_vtk(this->index_of_current_desired_time_to_output_velocity_field, current_time);
             
             // Update index s.t. it never goes out of bounds
             if(this->index_of_current_desired_time_to_output_velocity_field 

--- a/src/flow_solver/flow_solver_cases/periodic_turbulence.h
+++ b/src/flow_solver/flow_solver_cases/periodic_turbulence.h
@@ -97,6 +97,8 @@ protected:
     /// Directory for writting flow field files
     const std::string output_flow_field_files_directory_name;
 
+    const bool output_solution_at_exact_fixed_times;///< Flag for outputting the solution at exact fixed times by decreasing the time step on the fly
+
     /// Pointer to Navier-Stokes physics object for computing things on the fly
     std::shared_ptr< Physics::NavierStokes<dim,dim+2,double> > navier_stokes_physics;
 

--- a/src/flow_solver/flow_solver_cases/periodic_turbulence.h
+++ b/src/flow_solver/flow_solver_cases/periodic_turbulence.h
@@ -97,9 +97,6 @@ protected:
     /// Directory for writting flow field files
     const std::string output_flow_field_files_directory_name;
 
-    /// Flag for outputting the solution files (.vtu) at the velocity field output times
-    const bool output_solution_files_at_velocity_field_output_times;
-
     /// Pointer to Navier-Stokes physics object for computing things on the fly
     std::shared_ptr< Physics::NavierStokes<dim,dim+2,double> > navier_stokes_physics;
 

--- a/src/ode_solver/explicit_ode_solver.cpp
+++ b/src/ode_solver/explicit_ode_solver.cpp
@@ -15,6 +15,7 @@ RungeKuttaODESolver<dim,real,n_rk_stages, MeshType>::RungeKuttaODESolver(std::sh
 template <int dim, typename real, int n_rk_stages, typename MeshType> 
 void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::step_in_time (real dt, const bool pseudotime)
 {  
+    this->original_time_step = dt;
     this->solution_update = this->dg->solution; //storing u_n
 
     //calculating stages **Note that rk_stage[i] stores the RHS at a partial time-step (not solution u)
@@ -81,6 +82,7 @@ void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::step_in_time (real dt, 
     }
 
     modify_time_step(dt);
+    this->modified_time_step = dt;
 
     //assemble solution from stages
     for (int i = 0; i < n_rk_stages; ++i){

--- a/src/ode_solver/ode_solver_base.cpp
+++ b/src/ode_solver/ode_solver_base.cpp
@@ -11,10 +11,24 @@ ODESolverBase<dim,real,MeshType>::ODESolverBase(std::shared_ptr< DGBase<dim, rea
         , current_time(ode_param.initial_time)
         , current_iteration(ode_param.initial_iteration)
         , current_desired_time_for_output_solution_every_dt_time_intervals(ode_param.initial_desired_time_for_output_solution_every_dt_time_intervals)
+        , original_time_step(0.0)
+        , modified_time_step(0.0)
         , mpi_communicator(MPI_COMM_WORLD)
         , mpi_rank(dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD))
         , pcout(std::cout, mpi_rank==0)
         {}
+
+template <int dim, typename real, typename MeshType>
+double ODESolverBase<dim,real,MeshType>::get_original_time_step() const
+{
+    return this->original_time_step;
+}
+
+template <int dim, typename real, typename MeshType>
+double ODESolverBase<dim,real,MeshType>::get_modified_time_step() const
+{
+    return this->modified_time_step;
+}
 
 template <int dim, typename real, typename MeshType>
 void ODESolverBase<dim,real,MeshType>::initialize_steady_polynomial_ramping (const unsigned int global_final_poly_degree)

--- a/src/ode_solver/ode_solver_base.h
+++ b/src/ode_solver/ode_solver_base.h
@@ -105,6 +105,16 @@ public:
      *  if ODE parameter "output_solution_every_dt_time_intervals" > 0. */
     double current_desired_time_for_output_solution_every_dt_time_intervals;
 
+    /// Getter for original_time_step
+    double get_original_time_step() const;
+
+    /// Getter for modified_time_step
+    double get_modified_time_step() const;
+
+protected:
+    double original_time_step;///< Original time step before calling step_in_time
+    double modified_time_step;///< Modified time step after calling step_in_time
+
 protected:
     const MPI_Comm mpi_communicator; ///< MPI communicator.
     const int mpi_rank; ///< MPI rank.

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -273,10 +273,14 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       dealii::Patterns::Bool(),
                       "Outputs the high-order mesh vtu files. False by default");
 
-    prm.declare_entry("enable_higher_order_vtk_output", "false",
+    prm.declare_entry("enable_higher_order_vtk_output", "true",
                       dealii::Patterns::Bool(),
-                      "Enable writing of higher-order vtk files. False by default. If modified to true,"
-                      "number of subdivisions will be chosen according to the max of grid_degree and poly_degree.");
+                      "Enable writing of higher-order vtk files. True by default; "
+                      "number of subdivisions is chosen according to the max of grid_degree and poly_degree.");
+
+    prm.declare_entry("output_face_results_vtk", "false",
+                      dealii::Patterns::Bool(),
+                      "Outputs the surface solution vtk files. False by default");
 
     Parameters::LinearSolverParam::declare_parameters (prm);
     Parameters::ManufacturedConvergenceStudyParam::declare_parameters (prm);
@@ -420,6 +424,7 @@ void AllParameters::parse_parameters (dealii::ParameterHandler &prm)
     solution_vtk_files_directory_name = prm.get("solution_vtk_files_directory_name");
     output_high_order_grid = prm.get_bool("output_high_order_grid");
     enable_higher_order_vtk_output = prm.get_bool("enable_higher_order_vtk_output");
+    output_face_results_vtk = prm.get_bool("output_face_results_vtk");
 
     output_high_order_grid = prm.get_bool("output_high_order_grid");
 

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -261,6 +261,10 @@ public:
 
     /// Enable writing of higher-order vtk results
     bool enable_higher_order_vtk_output;
+
+    /// Flag for outputting the surface solution vtk files
+    bool output_face_results_vtk;
+    
     /// Declare parameters that can be set as inputs and set up the default options
     /** This subroutine should call the sub-parameter classes static declare_parameters()
       * such that each sub-parameter class is responsible to declare their own parameters.

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -91,5 +91,19 @@ void print_usage_message (dealii::ParameterHandler &prm)
     if (pcout.is_active()) prm.print_parameters (pcout.get_stream(), dealii::ParameterHandler::Text);
 }
 
+unsigned int get_number_of_values_in_string(const std::string string_of_values)
+{
+    std::string line = string_of_values;
+    unsigned int count = 0;
+    std::string::size_type sz1;
+    while(line!="" && line!=" ") {
+        count += 1;
+        std::stod(line,&sz1);
+        line = line.substr(sz1);
+        sz1 = 0;
+    }
+    return count;
+}
+
 } // Parameters namespace
 } // PHiLiP namespace

--- a/src/parameters/parameters.h
+++ b/src/parameters/parameters.h
@@ -2,6 +2,7 @@
 #define __PARAMETERS_H__
 
 #include <deal.II/base/parameter_handler.h>
+#include <string>
 
 namespace PHiLiP {
 namespace Parameters {
@@ -16,6 +17,9 @@ void print_usage_message (dealii::ParameterHandler &prm);
 /// into the dealii::ParameterHandler object
 void parse_command_line ( const int argc, char *const *argv,
                           dealii::ParameterHandler &parameter_handler);
+
+/// Returns the number of values in a given string
+unsigned int get_number_of_values_in_string(const std::string string_of_values);
 
 } // Parameters namespace
 } // PHiLiP namespace

--- a/src/parameters/parameters_flow_solver.cpp
+++ b/src/parameters/parameters_flow_solver.cpp
@@ -226,12 +226,7 @@ void FlowSolverParam::declare_parameters(dealii::ParameterHandler &prm)
             prm.declare_entry("output_velocity_field_times_string", " ",
                               dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
                               "String of the times at which to output the velocity field. "
-                              "Example: '0.0 1.0 2.0 3.0 '");
-
-            prm.declare_entry("number_of_times_to_output_velocity_field", "0",
-                              dealii::Patterns::Integer(0, dealii::Patterns::Integer::max_int_value),
-                              "Number of fixed times to output the velocity field. "
-                              "Must correspond to output_velocity_field_times_string.");
+                              "Example: '0.0 1.0 2.0 3.0 ' or '0.0 1.0 2.0 3.0'");
 
             prm.declare_entry("output_vorticity_magnitude_field_in_addition_to_velocity", "false",
                               dealii::Patterns::Bool(),
@@ -340,7 +335,7 @@ void FlowSolverParam::parse_parameters(dealii::ParameterHandler &prm)
         {
           output_velocity_field_at_fixed_times = prm.get_bool("output_velocity_field_at_fixed_times");
           output_velocity_field_times_string = prm.get("output_velocity_field_times_string");
-          number_of_times_to_output_velocity_field = prm.get_integer("number_of_times_to_output_velocity_field");
+          number_of_times_to_output_velocity_field = get_number_of_values_in_string(output_velocity_field_times_string);
           output_vorticity_magnitude_field_in_addition_to_velocity = prm.get_bool("output_vorticity_magnitude_field_in_addition_to_velocity");
           output_flow_field_files_directory_name = prm.get("output_flow_field_files_directory_name");
         }

--- a/src/parameters/parameters_flow_solver.cpp
+++ b/src/parameters/parameters_flow_solver.cpp
@@ -221,7 +221,7 @@ void FlowSolverParam::declare_parameters(dealii::ParameterHandler &prm)
         {
             prm.declare_entry("output_velocity_field_at_fixed_times", "false",
                               dealii::Patterns::Bool(),
-                              "Output velocity field (at equidistant nodes). False by default.");
+                              "Output velocity field (at equidistant nodes) at fixed times. False by default.");
 
             prm.declare_entry("output_velocity_field_times_string", " ",
                               dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
@@ -230,7 +230,7 @@ void FlowSolverParam::declare_parameters(dealii::ParameterHandler &prm)
 
             prm.declare_entry("number_of_times_to_output_velocity_field", "0",
                               dealii::Patterns::Integer(0, dealii::Patterns::Integer::max_int_value),
-                              "Number of times to output the velocity field. "
+                              "Number of fixed times to output the velocity field. "
                               "Must correspond to output_velocity_field_times_string.");
 
             prm.declare_entry("output_vorticity_magnitude_field_in_addition_to_velocity", "false",
@@ -240,10 +240,6 @@ void FlowSolverParam::declare_parameters(dealii::ParameterHandler &prm)
             prm.declare_entry("output_flow_field_files_directory_name", ".",
                               dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
                               "Name of directory for writing flow field files. Current directory by default.");
-
-            prm.declare_entry("output_solution_files_at_velocity_field_output_times", "false",
-                              dealii::Patterns::Bool(),
-                              "Output solution files (.vtu) at velocity field output times. False by default.");
         }
         prm.leave_subsection();
     }
@@ -347,7 +343,6 @@ void FlowSolverParam::parse_parameters(dealii::ParameterHandler &prm)
           number_of_times_to_output_velocity_field = prm.get_integer("number_of_times_to_output_velocity_field");
           output_vorticity_magnitude_field_in_addition_to_velocity = prm.get_bool("output_vorticity_magnitude_field_in_addition_to_velocity");
           output_flow_field_files_directory_name = prm.get("output_flow_field_files_directory_name");
-          output_solution_files_at_velocity_field_output_times = prm.get_bool("output_solution_files_at_velocity_field_output_times");
         }
         prm.leave_subsection();
     }

--- a/src/parameters/parameters_flow_solver.h
+++ b/src/parameters/parameters_flow_solver.h
@@ -96,12 +96,6 @@ public:
     /// For KHI, the atwood number
     double atwood_number;
 
-    /// Declares the possible variables and sets the defaults.
-    static void declare_parameters (dealii::ParameterHandler &prm);
-
-    /// Parses input file and sets the variables.
-    void parse_parameters (dealii::ParameterHandler &prm);
-
     /// Selects the method for applying the initial condition
     enum ApplyInitialConditionMethod{
         interpolate_initial_condition_function,
@@ -118,10 +112,15 @@ public:
 
     bool output_velocity_field_at_fixed_times; ///< Flag for outputting velocity field at fixed times
     std::string output_velocity_field_times_string; ///< String of velocity field output times
-    unsigned int number_of_times_to_output_velocity_field; ///< Number of times to output the velocity field
+    unsigned int number_of_times_to_output_velocity_field; ///< Number of fixed times to output the velocity field
     bool output_vorticity_magnitude_field_in_addition_to_velocity; ///< Flag for outputting vorticity magnitude field in addition to velocity field
     std::string output_flow_field_files_directory_name; ///< Name of directory for writing flow field files
-    bool output_solution_files_at_velocity_field_output_times; ///< Flag for outputting solution files at the velocity field output times
+
+    /// Declares the possible variables and sets the defaults.
+    static void declare_parameters (dealii::ParameterHandler &prm);
+
+    /// Parses input file and sets the variables.
+    void parse_parameters (dealii::ParameterHandler &prm);
 };
 
 } // Parameters namespace

--- a/src/parameters/parameters_ode_solver.cpp
+++ b/src/parameters/parameters_ode_solver.cpp
@@ -22,6 +22,20 @@ void ODESolverParam::declare_parameters (dealii::ParameterHandler &prm)
                           dealii::Patterns::Double(0,dealii::Patterns::Double::max_double_value),
                           "Outputs the solution at time intervals of dt in .vtk file");
 
+        prm.declare_entry("output_solution_at_fixed_times", "false",
+                          dealii::Patterns::Bool(),
+                          "Output solution at fixed times. False by default.");
+
+        prm.declare_entry("output_solution_fixed_times_string", " ",
+                          dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
+                          "String of the times at which to output the velocity field. "
+                          "Example: '0.0 1.0 2.0 3.0 '");
+
+        prm.declare_entry("number_of_fixed_times_to_output_solution", "0",
+                          dealii::Patterns::Integer(0, dealii::Patterns::Integer::max_int_value),
+                          "Number of fixed times to output the solution. "
+                          "Must correspond to output_solution_fixed_times_string.");
+
         prm.declare_entry("ode_solver_type", "implicit",
                           dealii::Patterns::Selection(
                           " runge_kutta | "
@@ -111,6 +125,9 @@ void ODESolverParam::parse_parameters (dealii::ParameterHandler &prm)
 
         output_solution_every_x_steps = prm.get_integer("output_solution_every_x_steps");
         output_solution_every_dt_time_intervals = prm.get_double("output_solution_every_dt_time_intervals");
+        output_solution_at_fixed_times = prm.get_bool("output_solution_at_fixed_times");
+        output_solution_fixed_times_string = prm.get("output_solution_fixed_times_string");
+        number_of_fixed_times_to_output_solution = prm.get_integer("number_of_fixed_times_to_output_solution");
 
         const std::string solver_string = prm.get("ode_solver_type");
         if (solver_string == "runge_kutta")                 ode_solver_type = ODESolverEnum::runge_kutta_solver;

--- a/src/parameters/parameters_ode_solver.cpp
+++ b/src/parameters/parameters_ode_solver.cpp
@@ -36,6 +36,11 @@ void ODESolverParam::declare_parameters (dealii::ParameterHandler &prm)
                           "Number of fixed times to output the solution. "
                           "Must correspond to output_solution_fixed_times_string.");
 
+        prm.declare_entry("output_solution_at_exact_fixed_times", "false",
+                          dealii::Patterns::Bool(),
+                          "Output solution at exact fixed times by decreasing the time step on the fly. False by default. "
+                          "NOTE: Should be set to false if doing stability studies so that the time step is never influenced by solution file soutput times.");
+
         prm.declare_entry("ode_solver_type", "implicit",
                           dealii::Patterns::Selection(
                           " runge_kutta | "
@@ -128,6 +133,7 @@ void ODESolverParam::parse_parameters (dealii::ParameterHandler &prm)
         output_solution_at_fixed_times = prm.get_bool("output_solution_at_fixed_times");
         output_solution_fixed_times_string = prm.get("output_solution_fixed_times_string");
         number_of_fixed_times_to_output_solution = prm.get_integer("number_of_fixed_times_to_output_solution");
+        output_solution_at_exact_fixed_times = prm.get_bool("output_solution_at_exact_fixed_times");
 
         const std::string solver_string = prm.get("ode_solver_type");
         if (solver_string == "runge_kutta")                 ode_solver_type = ODESolverEnum::runge_kutta_solver;

--- a/src/parameters/parameters_ode_solver.cpp
+++ b/src/parameters/parameters_ode_solver.cpp
@@ -29,12 +29,7 @@ void ODESolverParam::declare_parameters (dealii::ParameterHandler &prm)
         prm.declare_entry("output_solution_fixed_times_string", " ",
                           dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
                           "String of the times at which to output the velocity field. "
-                          "Example: '0.0 1.0 2.0 3.0 '");
-
-        prm.declare_entry("number_of_fixed_times_to_output_solution", "0",
-                          dealii::Patterns::Integer(0, dealii::Patterns::Integer::max_int_value),
-                          "Number of fixed times to output the solution. "
-                          "Must correspond to output_solution_fixed_times_string.");
+                          "Example: '0.0 1.0 2.0 3.0 ' or '0.0 1.0 2.0 3.0'");
 
         prm.declare_entry("output_solution_at_exact_fixed_times", "false",
                           dealii::Patterns::Bool(),
@@ -132,7 +127,7 @@ void ODESolverParam::parse_parameters (dealii::ParameterHandler &prm)
         output_solution_every_dt_time_intervals = prm.get_double("output_solution_every_dt_time_intervals");
         output_solution_at_fixed_times = prm.get_bool("output_solution_at_fixed_times");
         output_solution_fixed_times_string = prm.get("output_solution_fixed_times_string");
-        number_of_fixed_times_to_output_solution = prm.get_integer("number_of_fixed_times_to_output_solution");
+        number_of_fixed_times_to_output_solution = get_number_of_values_in_string(output_solution_fixed_times_string);
         output_solution_at_exact_fixed_times = prm.get_bool("output_solution_at_exact_fixed_times");
 
         const std::string solver_string = prm.get("ode_solver_type");

--- a/src/parameters/parameters_ode_solver.h
+++ b/src/parameters/parameters_ode_solver.h
@@ -26,6 +26,9 @@ public:
 
     int output_solution_every_x_steps; ///< Outputs the solution every x steps to .vtk file
     double output_solution_every_dt_time_intervals; ///< Outputs the solution every dt time intervals to .vtk file
+    bool output_solution_at_fixed_times; ///< Flag for outputting solution at fixed times
+    std::string output_solution_fixed_times_string; ///< String of fixed solution output times
+    unsigned int number_of_fixed_times_to_output_solution; ///< Number of fixed times to output the solution
 
     unsigned int nonlinear_max_iterations; ///< Maximum number of iterations.
     unsigned int print_iteration_modulo; ///< If ode_output==verbose, print every print_iteration_modulo iterations.

--- a/src/parameters/parameters_ode_solver.h
+++ b/src/parameters/parameters_ode_solver.h
@@ -29,6 +29,7 @@ public:
     bool output_solution_at_fixed_times; ///< Flag for outputting solution at fixed times
     std::string output_solution_fixed_times_string; ///< String of fixed solution output times
     unsigned int number_of_fixed_times_to_output_solution; ///< Number of fixed times to output the solution
+    bool output_solution_at_exact_fixed_times; ///< Flag for outputting the solution at exact fixed times by decreasing the time step on the fly
 
     unsigned int nonlinear_max_iterations; ///< Maximum number of iterations.
     unsigned int print_iteration_modulo; ///< If ode_output==verbose, print every print_iteration_modulo iterations.

--- a/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/dhit_init_check_mpi.prm
+++ b/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/dhit_init_check_mpi.prm
@@ -59,7 +59,6 @@ subsection flow_solver
   subsection output_velocity_field
     set output_velocity_field_at_fixed_times = true
     set output_velocity_field_times_string = 0.0
-    set number_of_times_to_output_velocity_field = 1
     set output_vorticity_magnitude_field_in_addition_to_velocity = true
   end
 end

--- a/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/dhit_init_check_serial.prm
+++ b/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/dhit_init_check_serial.prm
@@ -59,7 +59,6 @@ subsection flow_solver
   subsection output_velocity_field
     set output_velocity_field_at_fixed_times = true
     set output_velocity_field_times_string = 0.0
-    set number_of_times_to_output_velocity_field = 1
     set output_vorticity_magnitude_field_in_addition_to_velocity = true
   end
 end

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_subsonic_05_200.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_subsonic_05_200.prm
@@ -20,7 +20,7 @@ set conv_num_flux = roe
 set overintegration = 0
 
 #set sipg_penalty_factor = 20
-
+set output_face_results_vtk = true
 
 subsection euler
   set reference_length = 1.0

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_transonic_08_125.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_naca0012_transonic_08_125.prm
@@ -21,6 +21,7 @@ subsection artificial dissipation
 end
 
 set overintegration = 0
+set output_face_results_vtk = true
 
 subsection euler
   set reference_length = 1.0

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_subsonic_naca0012_lift_based_hp_adaptation.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_subsonic_naca0012_lift_based_hp_adaptation.prm
@@ -12,6 +12,8 @@ set use_split_form = false
 
 set overintegration = 10
 
+set output_face_results_vtk = true
+
 subsection euler
   set reference_length = 1.0
   set mach_infinity = 0.50

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_transonic_naca0012_drag_based_grid_adaptation.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_euler_transonic_naca0012_drag_based_grid_adaptation.prm
@@ -12,6 +12,8 @@ set use_split_form = false
 
 set overintegration = 0
 
+set output_face_results_vtk = true
+
 subsection euler
   set reference_length = 1.0
   set mach_infinity = 0.80

--- a/tests/integration_tests_control_files/euler_integration/naca0012/2d_navier_stokes_naca0012_subsonic_05_200.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/2d_navier_stokes_naca0012_subsonic_05_200.prm
@@ -9,6 +9,8 @@ set dimension = 2
 # The PDE we want to solve
 set pde_type  = navier_stokes
 
+set output_face_results_vtk = true
+
 #set conv_num_flux = lax_friedrichs #roe
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/euler_integration/naca0012/inviscid_transonic_steady_state_naca0012.prm
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/inviscid_transonic_steady_state_naca0012.prm
@@ -16,6 +16,8 @@ end
 
 set overintegration = 0
 
+set output_face_results_vtk = true
+
 subsection euler
   set reference_length = 1.0
   set mach_infinity = 0.80

--- a/tests/integration_tests_control_files/euler_naca_optimization/2d_euler_naca_optimization.prm
+++ b/tests/integration_tests_control_files/euler_naca_optimization/2d_euler_naca_optimization.prm
@@ -22,6 +22,8 @@ end
 
 set overintegration = 0
 
+set output_face_results_vtk = true
+
 set sipg_penalty_factor = 20
 
 subsection euler

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/CMakeLists.txt
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/CMakeLists.txt
@@ -100,3 +100,39 @@ add_test(
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
 # ----------------------------------------
+configure_file(viscous_TGV_energy_check_strong_adaptive_time_step.prm viscous_TGV_energy_check_strong_adaptive_time_step.prm COPYONLY)
+add_test(
+  NAME MPI_VISCOUS_TGV_STRONG_DG_ADAPTIVE_TIME_STEP
+  COMMAND bash -c 
+  "numprocs=1 ;
+  numprocstimestwo=$(( $numprocs * 2 )) ;
+  while [[ $numprocstimestwo -le $MPIMAX ]];
+  do 
+    numprocs=$numprocstimestwo;
+    numprocstimestwo=$(( $numprocs * 2 ));
+  done ;
+  mpirun -np $numprocs ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/viscous_TGV_energy_check_strong_adaptive_time_step.prm;
+  return_val=$? ;
+  if [ $return_val -ne 0 ]; then exit 1; else exit 0; fi"
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+# ----------------------------------------
+configure_file(viscous_tgv_strong_dg_adaptive_time_step_from_restart.sh
+viscous_tgv_strong_dg_adaptive_time_step_from_restart.sh COPYONLY)
+add_test(
+  NAME MPI_VISCOUS_TGV_STRONG_DG_ADAPTIVE_TIME_STEP_FROM_RESTART
+  COMMAND bash -c 
+  "./viscous_tgv_strong_dg_adaptive_time_step_from_restart.sh ${EXECUTABLE_OUTPUT_PATH}
+  return_val1=$? ;
+  numprocs=1 ;
+  numprocstimestwo=$(( $numprocs * 2 )) ;
+  while [[ $numprocstimestwo -le $MPIMAX ]];
+  do 
+    numprocs=$numprocstimestwo;
+    numprocstimestwo=$(( $numprocs * 2 ));
+  done ;
+  mpirun -np $numprocs ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/restart-00004.prm;
+  return_val2=$? ;
+  if [ $return_val2 -ne 0 ]; then exit 1; else exit 0; fi"
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
@@ -10,8 +10,8 @@ set pde_type = navier_stokes
 set use_weak_form = false
 # set flux_nodes_type = GLL
 
-set all_boundaries_are_periodic = true
-set check_same_coords_in_weak_dg = false
+# Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
+set use_periodic_bc = true
 
 # numerical fluxes
 set conv_num_flux = roe

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
@@ -22,7 +22,6 @@ subsection ODE solver
   set ode_output = quiet
   set output_solution_at_fixed_times = true
   set output_solution_fixed_times_string = 0.001 0.003 0.005 0.007 0.008 
-  set number_of_fixed_times_to_output_solution = 5
   set output_solution_at_exact_fixed_times = true
   set ode_solver_type = runge_kutta
   set runge_kutta_method = ssprk3_ex
@@ -62,6 +61,5 @@ subsection flow_solver
   subsection output_velocity_field
     set output_velocity_field_at_fixed_times = true
     set output_velocity_field_times_string = 0.005 0.007 0.008 
-    set number_of_times_to_output_velocity_field = 3
   end
 end

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
@@ -1,0 +1,67 @@
+# Listing of Parameters
+# ---------------------
+# Number of dimensions
+
+set dimension = 3
+set test_type = taylor_green_vortex_energy_check
+set pde_type = navier_stokes
+
+# DG formulation
+set use_weak_form = false
+# set flux_nodes_type = GLL
+
+set all_boundaries_are_periodic = true
+set check_same_coords_in_weak_dg = false
+
+# numerical fluxes
+set conv_num_flux = roe
+set diss_num_flux = symm_internal_penalty
+
+# ODE solver
+subsection ODE solver
+  set ode_output = quiet
+  set output_solution_at_fixed_times = true
+  set output_solution_fixed_times_string = 0.001 0.003 0.005 0.007 0.008 
+  set number_of_fixed_times_to_output_solution = 5
+  set output_solution_at_exact_fixed_times = true
+  set ode_solver_type = runge_kutta
+  set runge_kutta_method = ssprk3_ex
+end
+
+# Reference for freestream values specified below:
+# Diosady, L., and S. Murman. "Case 3.3: Taylor green vortex evolution." Case Summary for 3rd International Workshop on Higher-Order CFD Methods. 2015.
+
+# freestream Mach number
+subsection euler
+  set mach_infinity = 0.1
+end
+
+# freestream Reynolds number and Prandtl number
+subsection navier_stokes
+  set prandtl_number = 0.71
+  set reynolds_number_inf = 1600.0
+end
+
+subsection flow_solver
+  set flow_case_type = taylor_green_vortex
+  set poly_degree = 2
+  set final_time = 1.2566370614400000e-02
+  set courant_friedrichs_lewy_number = 0.03
+  set adaptive_time_step = true
+  set unsteady_data_table_filename = tgv_strong_adaptive_time_step
+  set output_restart_files = true
+  subsection grid
+    set grid_left_bound = 0.0
+    set grid_right_bound = 6.28318530717958623200
+    set number_of_grid_elements_per_dimension = 4
+  end
+  subsection taylor_green_vortex
+    set expected_kinetic_energy_at_final_time = 1.2073987159956494e-01
+    set expected_theoretical_dissipation_rate_at_final_time = 4.5422270072100499e-04
+  end
+  subsection output_velocity_field
+    set output_velocity_field_at_fixed_times = true
+    set output_velocity_field_times_string = 0.005 0.007 0.008 
+    set number_of_times_to_output_velocity_field = 3
+  end
+end

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_tgv_strong_dg_adaptive_time_step_from_restart.sh
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_tgv_strong_dg_adaptive_time_step_from_restart.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Assign the filename
+filename="tgv_strong_adaptive_time_step-restart-00004.txt"
+
+if [[ ! -f "${filename}" ]]; then
+    echo "ERROR: Cannot find file ${filename}. Must run MPI_VISCOUS_TGV_STRONG_DG_ADAPTIVE_TIME_STEP before running this test."
+fi


### PR DESCRIPTION
PR to incorporate improvements to the file output logic / features in `FlowSolver`. Commits were cherry picked from PR #199. Main contribution is the ability to output solution files at fixed set of times, exactly (by reducing the time step) or approximately (by not modifying the timestep). Includes the following:
- adding parameter flag `output_face_results_vtk` as `false` by default to suppress the output of `surface_solution` `vtk` files
- setting `enable_higher_order_vtk_output` as `true` by default 
- deprecating `output_solution_files_at_velocity_field_output_times`, can now output the solution `vtk` files at specific fixed times
- improved the time step update location in `FlowSolver` and its usage for outputting files
- integration test to verify the new features / improvements made in this PR: (1) `MPI_VISCOUS_TGV_STRONG_DG_ADAPTIVE_TIME_STEP`, and (2) `MPI_VISCOUS_TGV_STRONG_DG_ADAPTIVE_TIME_STEP_FROM_RESTART`