### PR TITLE
Lax-Friedrichs flux correction

### DIFF
--- a/src/numerical_flux/convective_numerical_flux.cpp
+++ b/src/numerical_flux/convective_numerical_flux.cpp
@@ -194,10 +194,10 @@ std::array<real, nstate> LaxFriedrichsRiemannSolverDissipation<dim,nstate,real>
 ::evaluate_riemann_solver_dissipation (
     const std::array<real, nstate> &soln_int,
     const std::array<real, nstate> &soln_ext,
-    const dealii::Tensor<1,dim,real> &/*normal_int*/) const
+    const dealii::Tensor<1,dim,real> &normal_int) const
 {
-    const real conv_max_eig_int = pde_physics->max_convective_eigenvalue(soln_int);
-    const real conv_max_eig_ext = pde_physics->max_convective_eigenvalue(soln_ext);
+    const real conv_max_eig_int = pde_physics->max_convective_normal_eigenvalue(soln_int,normal_int);
+    const real conv_max_eig_ext = pde_physics->max_convective_normal_eigenvalue(soln_ext,normal_int);
     // Replaced the std::max with an if-statement for the AD to work properly.
     //const real conv_max_eig = std::max(conv_max_eig_int, conv_max_eig_ext);
     real conv_max_eig;

--- a/src/numerical_flux/convective_numerical_flux.hpp
+++ b/src/numerical_flux/convective_numerical_flux.hpp
@@ -113,7 +113,12 @@ public:
     /// Destructor
     ~LaxFriedrichsRiemannSolverDissipation() {};
 
-    /// Returns the Lax-Friedrichs convective numerical flux at an interface.
+    /** Returns the Lax-Friedrichs convective numerical flux at an interface. 
+     *  Reference:
+     *    Section 3.1 of Bernardo Cockburn, and Chi-Wang Shu, 
+     *    "The Runge–Kutta Discontinuous Galerkin Method for Conservation Laws V", 
+     *    JOURNAL OF COMPUTATIONAL PHYSICS 141, 199–224 (1998).
+     * */
     std::array<real, nstate> evaluate_riemann_solver_dissipation (
         const std::array<real, nstate> &soln_int,
         const std::array<real, nstate> &soln_ext,

--- a/src/physics/burgers.h
+++ b/src/physics/burgers.h
@@ -92,7 +92,7 @@ public:
         const std::array<real,nstate> &/*solution*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
 
     /// Maximum viscous eigenvalue.

--- a/src/physics/convection_diffusion.h
+++ b/src/physics/convection_diffusion.h
@@ -91,7 +91,7 @@ public:
         const std::array<real,nstate> &/*solution*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
 
     /// Maximum viscous eigenvalue.

--- a/src/physics/euler.cpp
+++ b/src/physics/euler.cpp
@@ -928,7 +928,7 @@ real Euler<dim,nstate,real>
     const real sound = compute_sound (conservative_soln);
     real vel_dot_n = 0.0;
     for (int d=0;d<dim;++d) { vel_dot_n += vel[d]*normal[d]; };
-    const real max_normal_eig = sqrt(vel_dot_n*vel_dot_n) + sound;
+    const real max_normal_eig = abs(vel_dot_n) + sound;
 
     return max_normal_eig;
 }

--- a/src/physics/euler.cpp
+++ b/src/physics/euler.cpp
@@ -919,6 +919,22 @@ real Euler<dim,nstate,real>
 
 template <int dim, int nstate, typename real>
 real Euler<dim,nstate,real>
+::max_convective_normal_eigenvalue (
+    const std::array<real,nstate> &conservative_soln,
+    const dealii::Tensor<1,dim,real> &normal) const
+{
+    const dealii::Tensor<1,dim,real> vel = compute_velocities<real>(conservative_soln);
+
+    const real sound = compute_sound (conservative_soln);
+    real vel_dot_n = 0.0;
+    for (int d=0;d<dim;++d) { vel_dot_n += vel[d]*normal[d]; };
+    const real max_normal_eig = sqrt(vel_dot_n*vel_dot_n) + sound;
+
+    return max_normal_eig;
+}
+
+template <int dim, int nstate, typename real>
+real Euler<dim,nstate,real>
 ::max_viscous_eigenvalue (const std::array<real,nstate> &/*conservative_soln*/) const
 {
     return 0.0;

--- a/src/physics/euler.h
+++ b/src/physics/euler.h
@@ -160,8 +160,14 @@ public:
         const std::array<real,nstate> &/*conservative_soln*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
+
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs)
+    /** See the book I do like CFD, equation 3.6.18 */
+    real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const override;
 
     /// Maximum viscous eigenvalue.
     real max_viscous_eigenvalue (const std::array<real,nstate> &soln) const;

--- a/src/physics/large_eddy_simulation.cpp
+++ b/src/physics/large_eddy_simulation.cpp
@@ -150,6 +150,16 @@ real LargeEddySimulationBase<dim,nstate,real>
 }
 //----------------------------------------------------------------
 template <int dim, int nstate, typename real>
+real LargeEddySimulationBase<dim,nstate,real>
+::max_convective_normal_eigenvalue (
+    const std::array<real,nstate> &/*conservative_soln*/,
+    const dealii::Tensor<1,dim,real> &/*normal*/) const
+{
+    const real max_eig = 0.0;
+    return max_eig;
+}
+//----------------------------------------------------------------
+template <int dim, int nstate, typename real>
 std::array<real,nstate> LargeEddySimulationBase<dim,nstate,real>
 ::source_term (
         const dealii::Point<dim,real> &pos,

--- a/src/physics/large_eddy_simulation.h
+++ b/src/physics/large_eddy_simulation.h
@@ -66,6 +66,12 @@ public:
     /** For LES model, this value is assigned to be zero */
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
 
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs) of the additional models' PDEs
+    /** For LES model, this value is assigned to be zero */
+    real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const;
+
     /// Source term for manufactured solution functions
     std::array<real,nstate> source_term (
         const dealii::Point<dim,real> &pos,

--- a/src/physics/mhd.h
+++ b/src/physics/mhd.h
@@ -131,7 +131,7 @@ public:
         const std::array<real,nstate> &/*conservative_soln*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
 
     /// Maximum viscous eigenvalue.

--- a/src/physics/model.h
+++ b/src/physics/model.h
@@ -56,6 +56,12 @@ public:
     /** Note: Only support for zero convective term additional to the baseline physics */
     virtual real max_convective_eigenvalue (const std::array<real,nstate> &soln) const = 0;
 
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs) of the additional models' PDEs
+    /** Note: Only support for zero convective term additional to the baseline physics */
+    virtual real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const = 0;
+
     /// Physical source terms additional to the baseline physics (including physical source terms in additional PDEs of model)
     virtual std::array<real,nstate> physical_source_term (
         const dealii::Point<dim,real> &pos,

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -67,6 +67,15 @@ std::array<dealii::Tensor<1,dim,real>,nstate> PhysicsBase<dim,nstate,real>::conv
     return dummy;
 }
 
+template <int dim, int nstate, typename real>
+real PhysicsBase<dim,nstate,real>
+::max_convective_normal_eigenvalue (
+    const std::array<real,nstate> &conservative_soln,
+    const dealii::Tensor<1,dim,real> &/*normal*/) const
+{
+    return max_convective_eigenvalue(conservative_soln);
+}
+
 /*
 template <int dim, int nstate, typename real>
 std::array<dealii::Tensor<1,dim,real>,nstate> PhysicsBase<dim,nstate,real>

--- a/src/physics/physics.h
+++ b/src/physics/physics.h
@@ -83,8 +83,13 @@ public:
         const std::array<real,nstate> &/*solution*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const = 0;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     virtual real max_convective_eigenvalue (const std::array<real,nstate> &soln) const = 0;
+
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs)
+    virtual real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const;
 
     /// Maximum viscous eigenvalue.
     virtual real max_viscous_eigenvalue (const std::array<real,nstate> &soln) const = 0;

--- a/src/physics/physics_model.cpp
+++ b/src/physics/physics_model.cpp
@@ -265,6 +265,27 @@ real PhysicsModel<dim,nstate,real,nstate_baseline_physics>
 
 template <int dim, int nstate, typename real, int nstate_baseline_physics>
 real PhysicsModel<dim,nstate,real,nstate_baseline_physics>
+::max_convective_normal_eigenvalue (
+    const std::array<real,nstate> &conservative_soln,
+    const dealii::Tensor<1,dim,real> &normal) const
+{
+    real max_eig;
+    if constexpr(nstate==nstate_baseline_physics) {
+        max_eig = physics_baseline->max_convective_normal_eigenvalue(conservative_soln,normal);
+    } else {
+        max_eig = model->max_convective_normal_eigenvalue(conservative_soln,normal);
+        std::array<real,nstate_baseline_physics> baseline_conservative_soln;
+        for(int s=0; s<nstate_baseline_physics; ++s){
+            baseline_conservative_soln[s] = conservative_soln[s];
+        }
+        real baseline_max_eig = physics_baseline->max_convective_normal_eigenvalue(baseline_conservative_soln,normal);
+        max_eig = max_eig > baseline_max_eig ? max_eig : baseline_max_eig;
+    }
+    return max_eig;
+}
+
+template <int dim, int nstate, typename real, int nstate_baseline_physics>
+real PhysicsModel<dim,nstate,real,nstate_baseline_physics>
 ::max_viscous_eigenvalue (const std::array<real,nstate> &/*conservative_soln*/) const
 {
     return 0.0;

--- a/src/physics/physics_model.h
+++ b/src/physics/physics_model.h
@@ -82,8 +82,13 @@ public:
         const std::array<real,nstate> &/*solution*/,
         const dealii::Tensor<1,dim,real> &/*normal*/) const;
 
-    /// Maximum convective eigenvalue used in Lax-Friedrichs
+    /// Maximum convective eigenvalue
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
+
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs)
+    real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const override;
 
     /// Maximum viscous eigenvalue.
     real max_viscous_eigenvalue (const std::array<real,nstate> &soln) const;

--- a/src/physics/reynolds_averaged_navier_stokes.cpp
+++ b/src/physics/reynolds_averaged_navier_stokes.cpp
@@ -325,6 +325,23 @@ real ReynoldsAveragedNavierStokesBase<dim,nstate,real>
 }
 //----------------------------------------------------------------
 template <int dim, int nstate, typename real>
+real ReynoldsAveragedNavierStokesBase<dim,nstate,real>
+::max_convective_normal_eigenvalue (
+    const std::array<real,nstate> &conservative_soln,
+    const dealii::Tensor<1,dim,real> &normal) const
+{
+    const std::array<real,nstate_navier_stokes> conservative_soln_rans = extract_rans_conservative_solution(conservative_soln);
+
+    const dealii::Tensor<1,dim,real> vel = this->navier_stokes_physics->template compute_velocities<real>(conservative_soln_rans);
+
+    real vel_dot_n = 0.0;
+    for (int d=0;d<dim;++d) { vel_dot_n += vel[d]*normal[d]; };
+    const real max_normal_eig = sqrt(vel_dot_n*vel_dot_n);
+
+    return max_normal_eig;
+}
+//----------------------------------------------------------------
+template <int dim, int nstate, typename real>
 std::array<real,nstate> ReynoldsAveragedNavierStokesBase<dim,nstate,real>
 ::physical_source_term (
         const dealii::Point<dim,real> &pos,

--- a/src/physics/reynolds_averaged_navier_stokes.h
+++ b/src/physics/reynolds_averaged_navier_stokes.h
@@ -70,6 +70,13 @@ public:
      *  In most of the RANS models, the maximum eigenvalue of the convective flux is the flow velocity */
     real max_convective_eigenvalue (const std::array<real,nstate> &soln) const;
 
+    /// Maximum convective normal eigenvalue (used in Lax-Friedrichs) of the additional models' PDEs
+    /** For RANS model, this value is assigned to be the maximum eigenvalue of the turbulence model 
+     *  In most of the RANS models, the maximum normal eigenvalue of the convective flux is the flow normal velocity */
+    real max_convective_normal_eigenvalue (
+        const std::array<real,nstate> &soln,
+        const dealii::Tensor<1,dim,real> &normal) const;
+
     /// Source term for manufactured solution functions
     std::array<real,nstate> source_term (
         const dealii::Point<dim,real> &pos,


### PR DESCRIPTION
Using `max_convective_eigenvalue` in `LaxFriedrichsRiemannSolverDissipation<dim,nstate,real>::evaluate_riemann_solver_dissipation()`. Implemented for all physics with `nstate=dim+2` (Euler, NS, RANS); others use the definition in `PhysicsBase` which returns `max_convective_eigenvalue` to keep the same behavior for those classes. 
- Reference:  Section 3.1 of Bernardo Cockburn, and Chi-Wang Shu,  "The Runge–Kutta Discontinuous Galerkin Method for Conservation Laws V",   JOURNAL OF COMPUTATIONAL PHYSICS 141, 199–224 (1998).