### PR TITLE
Flow solver - make exact end time optional

### DIFF
--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -482,7 +482,7 @@ int FlowSolver<dim,nstate>::run() const
             time_step = next_time_step; // update time step
 
             // check if we need to decrease the time step
-            if((ode_solver->current_time+time_step) > final_time) {
+            if((ode_solver->current_time+time_step) > final_time && flow_solver_param.end_exactly_at_final_time) {
                 // decrease time step to finish exactly at specified final time
                 time_step = final_time - ode_solver->current_time;
             } else if (this->output_solution_at_exact_fixed_times && (this->do_output_solution_at_fixed_times && (this->number_of_fixed_times_to_output_solution > 0))) { // change this to some parameter

--- a/src/parameters/parameters_flow_solver.cpp
+++ b/src/parameters/parameters_flow_solver.cpp
@@ -237,6 +237,11 @@ void FlowSolverParam::declare_parameters(dealii::ParameterHandler &prm)
                               "Name of directory for writing flow field files. Current directory by default.");
         }
         prm.leave_subsection();
+
+        prm.declare_entry("end_exactly_at_final_time", "true",
+                          dealii::Patterns::Bool(),
+                          "Flag to adjust the last timestep such that the simulation "
+                          "ends exactly at final_time. True by default.");
     }
     prm.leave_subsection();
 }
@@ -340,6 +345,8 @@ void FlowSolverParam::parse_parameters(dealii::ParameterHandler &prm)
           output_flow_field_files_directory_name = prm.get("output_flow_field_files_directory_name");
         }
         prm.leave_subsection();
+
+        end_exactly_at_final_time = prm.get_bool("end_exactly_at_final_time");
     }
     prm.leave_subsection();
 }

--- a/src/parameters/parameters_flow_solver.h
+++ b/src/parameters/parameters_flow_solver.h
@@ -116,6 +116,8 @@ public:
     bool output_vorticity_magnitude_field_in_addition_to_velocity; ///< Flag for outputting vorticity magnitude field in addition to velocity field
     std::string output_flow_field_files_directory_name; ///< Name of directory for writing flow field files
 
+    bool end_exactly_at_final_time; ///< Flag to adjust the last timestep such that the simulation ends exactly at final_time
+
     /// Declares the possible variables and sets the defaults.
     static void declare_parameters (dealii::ParameterHandler &prm);
 

--- a/src/testing/time_refinement_study.cpp
+++ b/src/testing/time_refinement_study.cpp
@@ -27,6 +27,12 @@ Parameters::AllParameters TimeRefinementStudy<dim,nstate>::reinit_params_and_ref
      
      parameters.ode_solver_param.initial_time_step *= pow(refine_ratio,refinement);
      
+     //For RRK, do not end at exact time because of how relaxation parameter convergence is calculatd
+     using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
+     if (parameters.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
+        parameters.flow_solver_param.end_exactly_at_final_time = false;
+     }
+     
      return parameters;
 }
 

--- a/src/testing/time_refinement_study.cpp
+++ b/src/testing/time_refinement_study.cpp
@@ -27,7 +27,7 @@ Parameters::AllParameters TimeRefinementStudy<dim,nstate>::reinit_params_and_ref
 
     parameters.ode_solver_param.initial_time_step *= pow(refine_ratio,refinement);
 
-    //For RRK, do not end at exact time because of how relaxation parameter convergence is calculatd
+    //For RRK, do not end at exact time because of how relaxation parameter convergence is calculated
     using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
     if (parameters.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
         parameters.flow_solver_param.end_exactly_at_final_time = false;

--- a/src/testing/time_refinement_study.cpp
+++ b/src/testing/time_refinement_study.cpp
@@ -23,17 +23,17 @@ TimeRefinementStudy<dim, nstate>::TimeRefinementStudy(
 template <int dim, int nstate>
 Parameters::AllParameters TimeRefinementStudy<dim,nstate>::reinit_params_and_refine_timestep(int refinement) const
 {
-     PHiLiP::Parameters::AllParameters parameters = *(this->all_parameters);
-     
-     parameters.ode_solver_param.initial_time_step *= pow(refine_ratio,refinement);
-     
-     //For RRK, do not end at exact time because of how relaxation parameter convergence is calculatd
-     using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
-     if (parameters.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
+    PHiLiP::Parameters::AllParameters parameters = *(this->all_parameters);
+
+    parameters.ode_solver_param.initial_time_step *= pow(refine_ratio,refinement);
+
+    //For RRK, do not end at exact time because of how relaxation parameter convergence is calculatd
+    using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
+    if (parameters.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
         parameters.flow_solver_param.end_exactly_at_final_time = false;
-     }
-     
-     return parameters;
+    }
+
+    return parameters;
 }
 
 template <int dim, int nstate>
@@ -97,6 +97,7 @@ int TimeRefinementStudy<dim, nstate>::run_test() const
         pcout << "Computed error is " << L2_error << std::endl;
 
         const double dt =  params.ode_solver_param.initial_time_step;
+        const int n_timesteps= flow_solver->ode_solver->current_iteration;
         convergence_table.add_value("refinement", refinement);
         convergence_table.add_value("dt", dt );
         convergence_table.set_precision("dt", 16);
@@ -104,6 +105,17 @@ int TimeRefinementStudy<dim, nstate>::run_test() const
         convergence_table.add_value("L2_error",L2_error);
         convergence_table.set_precision("L2_error", 16);
         convergence_table.evaluate_convergence_rates("L2_error", "dt", dealii::ConvergenceTable::reduction_rate_log2, 1);
+        
+        using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
+        if(params.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
+            //for burgers, this is the average gamma over the runtime
+            const double final_time_actual = flow_solver->ode_solver->current_time;
+            const double gamma_aggregate_m1 = final_time_actual / (n_timesteps * dt)-1;
+            convergence_table.add_value("gamma_aggregate_m1", gamma_aggregate_m1);
+            convergence_table.set_precision("gamma_aggregate_m1", 16);
+            convergence_table.set_scientific("gamma_aggregate_m1", true);
+            convergence_table.evaluate_convergence_rates("gamma_aggregate_m1", "dt", dealii::ConvergenceTable::reduction_rate_log2, 1);
+        }
 
         //Checking convergence order
         const double expected_order = params.ode_solver_param.rk_order;

--- a/src/testing/time_refinement_study_reference.cpp
+++ b/src/testing/time_refinement_study_reference.cpp
@@ -37,6 +37,12 @@ Parameters::AllParameters TimeRefinementStudyReference<dim,nstate>::reinit_param
      
      parameters.ode_solver_param.initial_time_step *= pow(refine_ratio,refinement);
      
+     //For RRK, do not end at exact time because of how relaxation parameter convergence is calculatd
+     using ODESolverEnum = Parameters::ODESolverParam::ODESolverEnum;
+     if (parameters.ode_solver_param.ode_solver_type == ODESolverEnum::rrk_explicit_solver){
+        parameters.flow_solver_param.end_exactly_at_final_time = false;
+     }
+     
      return parameters;
 }
 


### PR DESCRIPTION
This is a follow-up to PR #211. The adjustment to finish exactly at `end_time` is good for most cases, but adjusting the target timestep size does not work well for RRK time refinement studies. Therefore, I am proposing to add a parameter to make this optional, and have adjusted the tests likewise.

The issue arises in the following case:
- Target timestep is decreased to reach final_time exactly.
- Adjusted timestep (from RRK) is smaller than target timestep.
- A second (very) small timestep is taken to reach final_time exactly.
This results in an extra timestep compared to the old behaviour, which invalidates the average relaxation parameter calculation.

The following text file demonstrates the behaviour:
[convergence_behaviour.txt](https://github.com/dougshidong/PHiLiP/files/11225668/convergence_behaviour.txt)
.

I've also included some improvements/corrections to the time refinement study tests from my branch in PR #195.