### PR TITLE
Flow Solver Memory Allocation Fix

### DIFF
--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -2095,7 +2095,7 @@ void DGBase<dim,real,MeshType>::allocate_system (
 
     dof_handler.distribute_dofs(fe_collection);
     //This Cuthill_McKee renumbering for dof_handlr uses a lot of memory in 3D, is there another way?
-    dealii::DoFRenumbering::Cuthill_McKee(dof_handler,true);
+    if(all_parameters->do_renumber_dofs) dealii::DoFRenumbering::Cuthill_McKee(dof_handler,true);
     //const bool reversed_numbering = true;
     //dealii::DoFRenumbering::Cuthill_McKee(dof_handler, reversed_numbering);
     //const bool reversed_numbering = false;

--- a/src/dg/dg.cpp
+++ b/src/dg/dg.cpp
@@ -2152,13 +2152,13 @@ void DGBase<dim,real,MeshType>::allocate_system (
     allocate_auxiliary_equation ();
 
     // System matrix allocation
-    dealii::DynamicSparsityPattern dsp(locally_relevant_dofs);
-    dealii::DoFTools::make_flux_sparsity_pattern(dof_handler, dsp);
-    dealii::SparsityTools::distribute_sparsity_pattern(dsp, dof_handler.locally_owned_dofs(), mpi_communicator, locally_relevant_dofs);
-
-    sparsity_pattern.copy_from(dsp);
-
     if (compute_dRdW || compute_dRdX || compute_d2R) {
+        dealii::DynamicSparsityPattern dsp(locally_relevant_dofs);
+        dealii::DoFTools::make_flux_sparsity_pattern(dof_handler, dsp);
+        dealii::SparsityTools::distribute_sparsity_pattern(dsp, dof_handler.locally_owned_dofs(), mpi_communicator, locally_relevant_dofs);
+
+        sparsity_pattern.copy_from(dsp);
+        
         system_matrix.reinit(locally_owned_dofs, sparsity_pattern, mpi_communicator);
     }
 

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -42,8 +42,8 @@ FlowSolver<dim, nstate>::FlowSolver(
 , dg(DGFactory<dim,double>::create_discontinuous_galerkin(&all_param, poly_degree, flow_solver_param.max_poly_degree_for_adaptation, grid_degree, flow_solver_case->generate_grid()))
 {
     flow_solver_case->set_higher_order_grid(dg);
-    if (ode_param.allocate_AD_matrices) {
-        pcout << "Note: Allocating DG with AD matrices." << std::endl;
+    if (ode_param.allocate_matrix_dRdW) {
+        pcout << "Note: Allocating DG with AD matrix dRdW only." << std::endl;
         dg->allocate_system(true,false,false); // FlowSolver only requires dRdW to be allocated
     } else {
         pcout << "Note: Allocating DG without AD matrices." << std::endl;

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -42,10 +42,12 @@ FlowSolver<dim, nstate>::FlowSolver(
 , dg(DGFactory<dim,double>::create_discontinuous_galerkin(&all_param, poly_degree, flow_solver_param.max_poly_degree_for_adaptation, grid_degree, flow_solver_case->generate_grid()))
 {
     flow_solver_case->set_higher_order_grid(dg);
-    if (flow_solver_param.steady_state == false) {
-        dg->allocate_system(false,false,false);
+    if (ode_param.allocate_AD_matrices) {
+        pcout << "Note: Allocating DG with AD matrices." << std::endl;
+        dg->allocate_system(true,false,false); // FlowSolver only requires dRdW to be allocated
     } else {
-        dg->allocate_system(true,false,false);
+        pcout << "Note: Allocating DG without AD matrices." << std::endl;
+        dg->allocate_system(false,false,false);
     }
 
     if(ode_param.ode_solver_type == Parameters::ODESolverParam::pod_galerkin_solver || ode_param.ode_solver_type == Parameters::ODESolverParam::pod_petrov_galerkin_solver){

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -45,7 +45,7 @@ FlowSolver<dim, nstate>::FlowSolver(
     if (flow_solver_param.steady_state == false) {
         dg->allocate_system(false,false,false);
     } else {
-        dg->allocate_system(true,true,true);
+        dg->allocate_system(true,false,false);
     }
 
     if(ode_param.ode_solver_type == Parameters::ODESolverParam::pod_galerkin_solver || ode_param.ode_solver_type == Parameters::ODESolverParam::pod_petrov_galerkin_solver){

--- a/src/flow_solver/flow_solver.cpp
+++ b/src/flow_solver/flow_solver.cpp
@@ -42,7 +42,11 @@ FlowSolver<dim, nstate>::FlowSolver(
 , dg(DGFactory<dim,double>::create_discontinuous_galerkin(&all_param, poly_degree, flow_solver_param.max_poly_degree_for_adaptation, grid_degree, flow_solver_case->generate_grid()))
 {
     flow_solver_case->set_higher_order_grid(dg);
-    dg->allocate_system();
+    if (flow_solver_param.steady_state == false) {
+        dg->allocate_system(false,false,false);
+    } else {
+        dg->allocate_system(true,true,true);
+    }
 
     if(ode_param.ode_solver_type == Parameters::ODESolverParam::pod_galerkin_solver || ode_param.ode_solver_type == Parameters::ODESolverParam::pod_petrov_galerkin_solver){
         std::shared_ptr<ProperOrthogonalDecomposition::OfflinePOD<dim>> pod = std::make_shared<ProperOrthogonalDecomposition::OfflinePOD<dim>>(dg);

--- a/src/ode_solver/explicit_ode_solver.cpp
+++ b/src/ode_solver/explicit_ode_solver.cpp
@@ -109,15 +109,17 @@ void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::modify_time_step(real &
 template <int dim, typename real, int n_rk_stages, typename MeshType> 
 void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::allocate_ode_system ()
 {
-    this->pcout << "Allocating ODE system..." << std::endl;
-    this->solution_update.reinit(this->dg->locally_owned_dofs, this->dg->ghost_dofs, this->mpi_communicator);
+    this->pcout << "Allocating ODE system..." << std::flush;
+    this->solution_update.reinit(this->dg->right_hand_side);
     if(this->all_parameters->use_inverse_mass_on_the_fly == false) {
+        this->pcout << " evaluating inverse mass matrix..." << std::flush;
         this->dg->evaluate_mass_matrices(true); // creates and stores global inverse mass matrix
     }
+    this->pcout << std::endl;
 
     this->rk_stage.resize(n_rk_stages);
     for (int i=0; i<n_rk_stages; ++i) {
-        this->rk_stage[i].reinit(this->dg->locally_owned_dofs, this->dg->ghost_dofs, this->mpi_communicator);
+        this->rk_stage[i].reinit(this->dg->solution);
     }
 
     this->butcher_tableau->set_tableau();

--- a/src/ode_solver/explicit_ode_solver.cpp
+++ b/src/ode_solver/explicit_ode_solver.cpp
@@ -109,7 +109,7 @@ void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::modify_time_step(real &
 template <int dim, typename real, int n_rk_stages, typename MeshType> 
 void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::allocate_ode_system ()
 {
-    this->pcout << "Allocating ODE system and evaluating inverse mass matrix..." << std::endl;
+    this->pcout << "Allocating ODE system..." << std::endl;
     this->solution_update.reinit(this->dg->locally_owned_dofs, this->dg->ghost_dofs, this->mpi_communicator);
     if(this->all_parameters->use_inverse_mass_on_the_fly == false) {
         this->dg->evaluate_mass_matrices(true); // creates and stores global inverse mass matrix

--- a/src/ode_solver/explicit_ode_solver.cpp
+++ b/src/ode_solver/explicit_ode_solver.cpp
@@ -110,14 +110,14 @@ template <int dim, typename real, int n_rk_stages, typename MeshType>
 void RungeKuttaODESolver<dim,real,n_rk_stages,MeshType>::allocate_ode_system ()
 {
     this->pcout << "Allocating ODE system and evaluating inverse mass matrix..." << std::endl;
-    this->solution_update.reinit(this->dg->right_hand_side);
+    this->solution_update.reinit(this->dg->locally_owned_dofs, this->dg->ghost_dofs, this->mpi_communicator);
     if(this->all_parameters->use_inverse_mass_on_the_fly == false) {
         this->dg->evaluate_mass_matrices(true); // creates and stores global inverse mass matrix
     }
 
     this->rk_stage.resize(n_rk_stages);
     for (int i=0; i<n_rk_stages; ++i) {
-        this->rk_stage[i].reinit(this->dg->solution);
+        this->rk_stage[i].reinit(this->dg->locally_owned_dofs, this->dg->ghost_dofs, this->mpi_communicator);
     }
 
     this->butcher_tableau->set_tableau();

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -286,7 +286,7 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
 
     prm.declare_entry("do_renumber_dofs", "true",
                       dealii::Patterns::Bool(),
-                      "Flag for renumbering DOFs. True by default. Set to false if doing 3D unsteady flow simulations.");
+                      "Flag for renumbering DOFs using Cuthill-McKee renumbering. True by default. Set to false if doing 3D unsteady flow simulations.");
 
     Parameters::LinearSolverParam::declare_parameters (prm);
     Parameters::ManufacturedConvergenceStudyParam::declare_parameters (prm);

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -284,6 +284,10 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       dealii::Patterns::Bool(),
                       "Outputs the surface solution vtk files. False by default");
 
+    prm.declare_entry("do_renumber_dofs", "true",
+                      dealii::Patterns::Bool(),
+                      "Flag for renumbering DOFs. True by default. Set to false if doing 3D unsteady flow simulations.");
+
     Parameters::LinearSolverParam::declare_parameters (prm);
     Parameters::ManufacturedConvergenceStudyParam::declare_parameters (prm);
     Parameters::ODESolverParam::declare_parameters (prm);
@@ -428,6 +432,7 @@ void AllParameters::parse_parameters (dealii::ParameterHandler &prm)
     output_high_order_grid = prm.get_bool("output_high_order_grid");
     enable_higher_order_vtk_output = prm.get_bool("enable_higher_order_vtk_output");
     output_face_results_vtk = prm.get_bool("output_face_results_vtk");
+    do_renumber_dofs = prm.get_bool("do_renumber_dofs");
 
     output_high_order_grid = prm.get_bool("output_high_order_grid");
 

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -265,6 +265,9 @@ public:
 
     /// Flag for outputting the surface solution vtk files
     bool output_face_results_vtk;
+
+    /// Flag for renumbering DOFs
+    bool do_renumber_dofs;
     
     /// Declare parameters that can be set as inputs and set up the default options
     /** This subroutine should call the sub-parameter classes static declare_parameters()

--- a/src/parameters/parameters_ode_solver.cpp
+++ b/src/parameters/parameters_ode_solver.cpp
@@ -130,18 +130,18 @@ void ODESolverParam::parse_parameters (dealii::ParameterHandler &prm)
         number_of_fixed_times_to_output_solution = get_number_of_values_in_string(output_solution_fixed_times_string);
         output_solution_at_exact_fixed_times = prm.get_bool("output_solution_at_exact_fixed_times");
 
-        // Assign ode_solver_type and the allocate_AD_matrices flag
+        // Assign ode_solver_type and the allocate AD matrix dRdW flag
         const std::string solver_string = prm.get("ode_solver_type");
         if (solver_string == "runge_kutta")              { ode_solver_type = ODESolverEnum::runge_kutta_solver;
-                                                           allocate_AD_matrices = false; }
+                                                           allocate_matrix_dRdW = false; }
         else if (solver_string == "implicit")            { ode_solver_type = ODESolverEnum::implicit_solver;
-                                                           allocate_AD_matrices = true; }
+                                                           allocate_matrix_dRdW = true; }
         else if (solver_string == "rrk_explicit")        { ode_solver_type = ODESolverEnum::rrk_explicit_solver;
-                                                           allocate_AD_matrices = false; }
+                                                           allocate_matrix_dRdW = false; }
         else if (solver_string == "pod_galerkin")        { ode_solver_type = ODESolverEnum::pod_galerkin_solver;
-                                                           allocate_AD_matrices = true; }
+                                                           allocate_matrix_dRdW = true; }
         else if (solver_string == "pod_petrov_galerkin") { ode_solver_type = ODESolverEnum::pod_petrov_galerkin_solver;
-                                                           allocate_AD_matrices = true; }
+                                                           allocate_matrix_dRdW = true; }
 
         nonlinear_steady_residual_tolerance  = prm.get_double("nonlinear_steady_residual_tolerance");
         nonlinear_max_iterations = prm.get_integer("nonlinear_max_iterations");

--- a/src/parameters/parameters_ode_solver.cpp
+++ b/src/parameters/parameters_ode_solver.cpp
@@ -130,12 +130,18 @@ void ODESolverParam::parse_parameters (dealii::ParameterHandler &prm)
         number_of_fixed_times_to_output_solution = get_number_of_values_in_string(output_solution_fixed_times_string);
         output_solution_at_exact_fixed_times = prm.get_bool("output_solution_at_exact_fixed_times");
 
+        // Assign ode_solver_type and the allocate_AD_matrices flag
         const std::string solver_string = prm.get("ode_solver_type");
-        if (solver_string == "runge_kutta")                 ode_solver_type = ODESolverEnum::runge_kutta_solver;
-        else if (solver_string == "implicit")               ode_solver_type = ODESolverEnum::implicit_solver;
-        else if (solver_string == "rrk_explicit")           ode_solver_type = ODESolverEnum::rrk_explicit_solver;
-        else if (solver_string == "pod_galerkin")           ode_solver_type = ODESolverEnum::pod_galerkin_solver;
-        else if (solver_string == "pod_petrov_galerkin")    ode_solver_type = ODESolverEnum::pod_petrov_galerkin_solver;
+        if (solver_string == "runge_kutta")              { ode_solver_type = ODESolverEnum::runge_kutta_solver;
+                                                           allocate_AD_matrices = false; }
+        else if (solver_string == "implicit")            { ode_solver_type = ODESolverEnum::implicit_solver;
+                                                           allocate_AD_matrices = true; }
+        else if (solver_string == "rrk_explicit")        { ode_solver_type = ODESolverEnum::rrk_explicit_solver;
+                                                           allocate_AD_matrices = false; }
+        else if (solver_string == "pod_galerkin")        { ode_solver_type = ODESolverEnum::pod_galerkin_solver;
+                                                           allocate_AD_matrices = true; }
+        else if (solver_string == "pod_petrov_galerkin") { ode_solver_type = ODESolverEnum::pod_petrov_galerkin_solver;
+                                                           allocate_AD_matrices = true; }
 
         nonlinear_steady_residual_tolerance  = prm.get_double("nonlinear_steady_residual_tolerance");
         nonlinear_max_iterations = prm.get_integer("nonlinear_max_iterations");

--- a/src/parameters/parameters_ode_solver.h
+++ b/src/parameters/parameters_ode_solver.h
@@ -67,6 +67,9 @@ public:
     int n_rk_stages; ///< Number of stages for an RK method; assigned based on runge_kutta_method
     int rk_order; ///< Order of the RK method; assigned based on runge_kutta_method
 
+    /// Flag to signal that automatic differentiation (AD) matrices must be allocated
+    bool allocate_AD_matrices;
+
     static void declare_parameters (dealii::ParameterHandler &prm); ///< Declares the possible variables and sets the defaults.
     void parse_parameters (dealii::ParameterHandler &prm); ///< Parses input file and sets the variables.
 };

--- a/src/parameters/parameters_ode_solver.h
+++ b/src/parameters/parameters_ode_solver.h
@@ -67,8 +67,8 @@ public:
     int n_rk_stages; ///< Number of stages for an RK method; assigned based on runge_kutta_method
     int rk_order; ///< Order of the RK method; assigned based on runge_kutta_method
 
-    /// Flag to signal that automatic differentiation (AD) matrices must be allocated
-    bool allocate_AD_matrices;
+    /// Flag to signal that automatic differentiation (AD) matrix dRdW must be allocated
+    bool allocate_matrix_dRdW;
 
     static void declare_parameters (dealii::ParameterHandler &prm); ///< Declares the possible variables and sets the defaults.
     void parse_parameters (dealii::ParameterHandler &prm); ///< Parses input file and sets the variables.

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_WALE_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_WALE_model_energy_check_quick.prm
@@ -14,6 +14,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_WALE_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_WALE_model_energy_check_quick.prm
@@ -14,7 +14,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_smagorinsky_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_smagorinsky_model_energy_check_quick.prm
@@ -14,6 +14,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_smagorinsky_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_smagorinsky_model_energy_check_quick.prm
@@ -14,7 +14,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_vreman_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_vreman_model_energy_check_quick.prm
@@ -14,6 +14,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_vreman_model_energy_check_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_LES_vreman_model_energy_check_quick.prm
@@ -14,7 +14,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
@@ -13,7 +13,7 @@ set use_weak_form = false
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_TGV_energy_check_strong_adaptive_time_step.prm
@@ -13,6 +13,9 @@ set use_weak_form = false
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gl_flux_nodes_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gl_flux_nodes_quick.prm
@@ -17,6 +17,9 @@ set use_periodic_bc = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set two_point_num_flux_type = IR
 set conv_num_flux = two_point_flux

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gl_flux_nodes_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gl_flux_nodes_quick.prm
@@ -17,7 +17,7 @@ set use_periodic_bc = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gll_flux_nodes_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gll_flux_nodes_quick.prm
@@ -17,6 +17,9 @@ set use_periodic_bc = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set two_point_num_flux_type = IR
 set conv_num_flux = two_point_flux

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gll_flux_nodes_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_nsfr_gll_flux_nodes_quick.prm
@@ -17,7 +17,7 @@ set use_periodic_bc = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_strong_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_strong_quick.prm
@@ -13,7 +13,7 @@ set use_weak_form = false
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_strong_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_strong_quick.prm
@@ -13,6 +13,9 @@ set use_weak_form = false
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_long.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_long.prm
@@ -13,7 +13,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_long.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_long.prm
@@ -13,6 +13,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_quick.prm
@@ -13,7 +13,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_quick.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_energy_check_weak_quick.prm
@@ -13,6 +13,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_restart_check.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_restart_check.prm
@@ -13,7 +13,7 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
-# memory allocation
+# degree of freedom renumbering not necessary for explicit time advancement cases
 set do_renumber_dofs = false
 
 # numerical fluxes

--- a/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_restart_check.prm
+++ b/tests/integration_tests_control_files/taylor_green_vortex_integration/viscous_taylor_green_vortex_restart_check.prm
@@ -13,6 +13,9 @@ set use_weak_form = true
 # Note: this was added to turn off check_same_coords() -- has no other function when dim!=1
 set use_periodic_bc = true
 
+# memory allocation
+set do_renumber_dofs = false
+
 # numerical fluxes
 set conv_num_flux = roe
 set diss_num_flux = symm_internal_penalty


### PR DESCRIPTION
PR to incorporate fixes that @AlexanderCicchino discovered in terms of DG's and explicit ODE solver's allocation. This fix also now passes the necessary flags to `allocate_system` within Flow Solver. On the current version of master, for a viscous TGV simulation a total of 4^3 elements, the maximum polynomial degree I could get the code to allocate/run **locally** (32GB of ram, 8 processors), was **P5**. With these changes, I am now able to run **P15** with the same number of elements on the same computer (32GB of ram, 8 processors). This is expected to solve the memory allocation issues I've been having on the cluster. 