### PR TITLE
Simple stage value prediction for implicit RK

### DIFF
--- a/src/ode_solver/JFNK_solver/JFNK_solver.cpp
+++ b/src/ode_solver/JFNK_solver/JFNK_solver.cpp
@@ -27,13 +27,19 @@ JFNKSolver<dim,real,MeshType>::JFNKSolver(std::shared_ptr< DGBase<dim, real, Mes
 
 template <int dim, typename real, typename MeshType>
 void JFNKSolver<dim,real,MeshType>::solve (real dt,
-        dealii::LinearAlgebra::distributed::Vector<double> &previous_step_solution)
+        dealii::LinearAlgebra::distributed::Vector<double> &previous_step_solution,
+        real stage_dt
+        )
 { 
     double update_norm = 1.0;
     int Newton_iter_counter = 0;
     
     jacobian_vector_product.reinit_for_next_timestep(dt, perturbation_magnitude, previous_step_solution);
+
+    //stage value prediction
     current_solution_estimate = previous_step_solution;
+    current_solution_estimate.add(stage_dt, slope_at_previous_step);
+
     solution_update_newton.reinit(previous_step_solution);
 
     while ((update_norm > epsilon_Newton) && (Newton_iter_counter < max_Newton_iter)){

--- a/src/ode_solver/JFNK_solver/JFNK_solver.h
+++ b/src/ode_solver/JFNK_solver/JFNK_solver.h
@@ -25,7 +25,8 @@ public:
      * Calls solver_GMRES.solve(...) for inner loop (GMRES iterations)
      */
     void solve(real dt,
-               dealii::LinearAlgebra::distributed::Vector<double> &previous_step_solution);
+               dealii::LinearAlgebra::distributed::Vector<double> &previous_step_solution,
+               real stage_dt);
 
     /// current estimate for the solution
     dealii::LinearAlgebra::distributed::Vector<double> current_solution_estimate;
@@ -73,6 +74,11 @@ protected:
     
     /// Update to solution during Newton iterations
     dealii::LinearAlgebra::distributed::Vector<double> solution_update_newton;
+public:    
+    /// Store slope calculated at previous time step
+    /** Used in stage value prediction
+     */
+    dealii::LinearAlgebra::distributed::Vector<double> slope_at_previous_step;
 };
 
 }

--- a/src/ode_solver/runge_kutta_ode_solver.h
+++ b/src/ode_solver/runge_kutta_ode_solver.h
@@ -48,6 +48,9 @@ protected:
     
     /// Indicator for zero diagonal elements; used to toggle implicit solve.
     std::vector<bool> butcher_tableau_aii_is_zero;
+
+    /// Flag for ANY implicit stages, initialize to false
+    bool butcher_tableau_has_implicit_stages = false;
 };
 
 } // ODE namespace


### PR DESCRIPTION
The JFNK solver for diagonally-implicit Runge-Kutta used to use the previous stage value as the initial guess for nonlinear iterations:
$u^(i)_0$ = $u^{(i-1)}$ where superscripts in parentheses indicate stage values.

I modified the implicit solver to use a better stage value prediction: 
$u^(i)_0 = c_i \Delta t \ RHS(u^n)$ 
That is, I store the slope at the previous time step and use linear extrapolation to the "stage time", $c_i \Delta t$. 

The same test took 14h to run before making this change and 11h after adding the better stage value prediction. For the cost of adding a residual evaluation and storing the slope $RHS(u^n)$, the JFNK solver needs to perform fewer iterations.

I propose making this a hard-coded change because it is unlikely to ever degrade performance, and only impacts a very small part of the code. If I add better stage value prediction in the future, I will code this more carefully. Section 2.18 of the Kennedy & Carpenter [review](https://ntrs.nasa.gov/citations/20160005923) on DIRK methods describes this SVP alongside many other more complex ones.

_Draft while I clean up the changes..._