### PR TITLE
Updated test criterion of a mesh adaptation case.

### DIFF
--- a/src/testing/anisotropic_mesh_adaptation_cases.h
+++ b/src/testing/anisotropic_mesh_adaptation_cases.h
@@ -26,6 +26,9 @@ public:
 
     /// Checks PHiLiP::FEValuesShapeHessian for MappingFEField with dealii's shape hessian for MappingQGeneric.
     void verify_fe_values_shape_hessian(const DGBase<dim, double> &dg) const;
+    
+    /// Evaluates \f[ J(u_h) \f].
+    double evaluate_functional(std::shared_ptr<DGBase<dim,double>> dg) const;
 }; 
 
 } // Tests namespace

--- a/tests/integration_tests_control_files/grid_refinement/anisotropic_mesh_adaptation_sshock.prm
+++ b/tests/integration_tests_control_files/grid_refinement/anisotropic_mesh_adaptation_sshock.prm
@@ -27,7 +27,7 @@ subsection mesh adaptation
   set mesh_adaptation_type = anisotropic_adaptation
   set use_goal_oriented_mesh_adaptation = true
   subsection anisotropic
-    set mesh_complexity_anisotropic_adaptation = 50.0
+    set mesh_complexity_anisotropic_adaptation = 100.0
     set norm_Lp_anisotropic_adaptation = 1.0
   end
 end
@@ -77,6 +77,6 @@ subsection flow_solver
   set poly_degree = 1
   set max_poly_degree_for_adaptation = 2
   subsection grid
-    set number_of_mesh_refinements = 4
+    set number_of_mesh_refinements = 2
   end
 end


### PR DESCRIPTION
One of the mesh adaptation test cases was failing for some gmsh versions due to a tighter test tolerance. The criteria for that test case has now been updated which should fix this issue. 