### PR TITLE
Adding Labels to Ctests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,30 @@
+## Function to set test labels
+## Test labels should be added for the following categories (USE ALL CAPS)
+## - Type of Test
+#	- UNIT_TEST, INTEGRATION_TEST
+#- Speed of Test
+#	- QUICK, SLOW
+#- Test Group
+#	- NNLS, REDUCED ORDER, ETC
+#- Usage (if needed)
+#	- MEMORY_INTENSIVE
+#- Dimension
+#   - 1D, 2D, 3D
+#- PDE Type
+#   - EULER, NAVIER-STOKES
+#- Quadrature Type
+#   - COLOCATED, UNCOLOCATED
+#- DG Type
+#   - STRONG, WEAK
+#- ODE Solver Type
+#   - RUNGE-KUTTA, IMPLICIT, ETC
+#- Parallel vs Serial
+#   - PARALLEL, SERIAL
+function(set_tests_labels test_name)
+    set(labels ${ARGN})
+    set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
+endfunction()
+
 add_subdirectory(unit_tests)
 add_subdirectory(integration_tests_control_files)
 add_subdirectory(meshes)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,33 @@
 ## Function to set test labels
 ## Test labels should be added for the following categories (USE ALL CAPS)
-## - Type of Test
-#	- UNIT_TEST, INTEGRATION_TEST
-#- Speed of Test
-#	- QUICK, SLOW
 #- Test Group
-#	- NNLS, REDUCED ORDER, ETC
-#- Usage (if needed)
-#	- MEMORY_INTENSIVE
+#	- NNLS, TGV_SCALING, ETC
 #- Dimension
 #   - 1D, 2D, 3D
-#- PDE Type
-#   - EULER, NAVIER-STOKES
-#- Quadrature Type
-#   - COLOCATED, UNCOLOCATED
-#- DG Type
-#   - STRONG, WEAK
-#- ODE Solver Type
-#   - RUNGE-KUTTA, IMPLICIT, ETC
 #- Parallel vs Serial
 #   - PARALLEL, SERIAL
+#- PDE Type
+#   - EULER, NAVIER-STOKES, etc
+#- ODE Solver Type
+#   - RUNGE-KUTTA, IMPLICIT, etc
+#- DG Type
+#   - STRONG, STRONG-SPLIT, WEAK
+#- Quadrature Type
+#   - COLLOCATED, UNCOLLOCATED
+#- OTHER (if needed)
+#	- MEMORY_INTENSIVE, MANUFACTURED_SOLUTION, EXPECTED_FAILURE etc
+#- Speed of Test
+#	- QUICK (<~10s), MODERATE(<~180s), LONG(>~180s)
+#- Type of Test
+#	- UNIT_TEST, INTEGRATION_TEST, FLOW_SIMULATION, CONVERGENCE (Add to other)?
+
+
+
+
+
+
+
+
 function(set_tests_labels test_name)
     set(labels ${ARGN})
     set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")

--- a/tests/integration_tests_control_files/1d_shock/CMakeLists.txt
+++ b/tests/integration_tests_control_files/1d_shock/CMakeLists.txt
@@ -6,3 +6,13 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_shock.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_SHOCKED_MANUFACTURED_SOLUTION   1D_SHOCK
+                                                    1D
+                                                    SERIAL
+                                                    BURGERS_INVISCID
+                                                    RUNGE-KUTTA
+                                                    WEAK
+                                                    COLLOCATED
+                                                    MANUFACTURED_SOLUTION
+                                                    MODERATE
+                                                    INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/1d_shock/CMakeLists.txt
+++ b/tests/integration_tests_control_files/1d_shock/CMakeLists.txt
@@ -12,7 +12,7 @@ set_tests_labels(1D_SHOCKED_MANUFACTURED_SOLUTION   1D_SHOCK
                                                     BURGERS_INVISCID
                                                     RUNGE-KUTTA
                                                     WEAK
-                                                    COLLOCATED
+                                                    UNCOLLOCATED
                                                     MANUFACTURED_SOLUTION
                                                     MODERATE
                                                     INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/advection_explicit_periodic/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_explicit_periodic/CMakeLists.txt
@@ -5,6 +5,16 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_advection_explicit_periodic_energy.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_LONG ADVECTION_EXPLICIT_PERIODIC
+                                                                2D
+                                                                PARALLEL
+                                                                ADVECTION
+                                                                RUNGE-KUTTA
+                                                                STRONG
+                                                                COLLOCATED
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
+
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(2D_advection_explicit_periodic_OOA.prm 2D_advection_explicit_periodic_OOA.prm COPYONLY)
 add_test(
@@ -12,7 +22,15 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_advection_explicit_periodic_OOA.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_OOA_LONG    ADVECTION_EXPLICIT_PERIODIC
+                                                                2D
+                                                                PARALLEL
+                                                                ADVECTION
+                                                                RUNGE-KUTTA
+                                                                STRONG
+                                                                COLLOCATED
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(2D_advection_explicit_periodic_energy_weight_adjusted.prm 2D_advection_explicit_periodic_energy_weight_adjusted.prm COPYONLY)
 add_test(
@@ -20,7 +38,15 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_advection_explicit_periodic_energy_weight_adjusted.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_LONG ADVECTION_EXPLICIT_PERIODIC
+                                                                                2D
+                                                                                PARALLEL
+                                                                                ADVECTION
+                                                                                RUNGE-KUTTA
+                                                                                STRONG
+                                                                                COLLOCATED
+                                                                                MODERATE
+                                                                                INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(2D_advection_explicit_periodic_energy_weight_adjusted_on_the_fly.prm 2D_advection_explicit_periodic_energy_weight_adjusted_on_the_fly.prm COPYONLY)
 add_test(
@@ -28,7 +54,15 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_advection_explicit_periodic_energy_weight_adjusted_on_the_fly.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_ON_THE_FLY_LONG  ADVECTION_EXPLICIT_PERIODIC
+                                                                                            2D
+                                                                                            PARALLEL
+                                                                                            ADVECTION
+                                                                                            RUNGE-KUTTA
+                                                                                            STRONG
+                                                                                            COLLOCATED
+                                                                                            MODERATE
+                                                                                            INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_advection_explicit_periodic_energy_weight_adjusted.prm 3D_advection_explicit_periodic_energy_weight_adjusted.prm COPYONLY)
 add_test(
@@ -36,3 +70,12 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_advection_explicit_periodic_energy_weight_adjusted.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_LONG     ADVECTION_EXPLICIT_PERIODIC
+                                                                                    3D
+                                                                                    PARALLEL
+                                                                                    ADVECTION
+                                                                                    RUNGE-KUTTA
+                                                                                    STRONG
+                                                                                    COLLOCATED
+                                                                                    LONG
+                                                                                    INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/advection_explicit_periodic/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_explicit_periodic/CMakeLists.txt
@@ -11,7 +11,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_LONG ADVECTION_EXPLIC
                                                                 ADVECTION
                                                                 RUNGE-KUTTA
                                                                 STRONG
-                                                                COLLOCATED
+                                                                UNCOLLOCATED
                                                                 MODERATE
                                                                 INTEGRATION_TEST)
 
@@ -28,7 +28,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_OOA_LONG    ADVECTION_EXPLIC
                                                                 ADVECTION
                                                                 RUNGE-KUTTA
                                                                 STRONG
-                                                                COLLOCATED
+                                                                UNCOLLOCATED
                                                                 MODERATE
                                                                 INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -44,7 +44,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_LONG 
                                                                                 ADVECTION
                                                                                 RUNGE-KUTTA
                                                                                 STRONG
-                                                                                COLLOCATED
+                                                                                UNCOLLOCATED
                                                                                 MODERATE
                                                                                 INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -60,7 +60,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_ON_TH
                                                                                             ADVECTION
                                                                                             RUNGE-KUTTA
                                                                                             STRONG
-                                                                                            COLLOCATED
+                                                                                            UNCOLLOCATED
                                                                                             MODERATE
                                                                                             INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -76,6 +76,6 @@ set_tests_labels(MPI_3D_ADVECTION_EXPLICIT_PERIODIC_ENERGY_WEIGHT_ADJUSTED_LONG 
                                                                                     ADVECTION
                                                                                     RUNGE-KUTTA
                                                                                     STRONG
-                                                                                    COLLOCATED
+                                                                                    UNCOLLOCATED
                                                                                     LONG
                                                                                     INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/advection_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_implicit/CMakeLists.txt
@@ -6,6 +6,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_advection_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLICIT
+                                                                1D
+                                                                SERIAL
+                                                                ADVECTION
+                                                                IMPLICIT
+                                                                WEAK
+                                                                COLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                QUICK
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_advection_implicit.prm 2d_advection_implicit.prm COPYONLY)
 add_test(
@@ -13,6 +23,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLICIT
+                                                                2D
+                                                                SERIAL
+                                                                ADVECTION
+                                                                IMPLICIT
+                                                                WEAK
+                                                                COLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_advection_explicit.prm 2d_advection_explicit.prm COPYONLY)
 add_test(
@@ -20,6 +40,16 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_explicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_LONG   ADVECTION_IMPLICIT
+                                                                        2D
+                                                                        PARALLEL
+                                                                        ADVECTION
+                                                                        RUNGE-KUTTA
+                                                                        WEAK
+                                                                        COLLOCATED
+                                                                        MANUFACTURED_SOLUTION
+                                                                        LONG
+                                                                        INTEGRATION_TEST)
 
 configure_file(2d_advection_implicit.prm 2d_advection_implicit.prm COPYONLY)
 add_test(
@@ -27,6 +57,16 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLICIT
+                                                                    2D
+                                                                    PARALLEL
+                                                                    ADVECTION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    COLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
 
 configure_file(3d_advection_implicit.prm 3d_advection_implicit.prm COPYONLY)
 add_test(
@@ -34,6 +74,16 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_advection_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLICIT
+                                                                    3D
+                                                                    PARALLEL
+                                                                    ADVECTION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    COLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    MODERATE
+                                                                    INTEGRATION_TEST)
 
 # Tests for strong form
 configure_file(1d_advection_implicit_strong.prm 1d_advection_implicit_strong.prm COPYONLY)
@@ -42,6 +92,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_advection_implicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTION_IMPLICIT
+                                                                    1D
+                                                                    SERIAL
+                                                                    ADVECTION
+                                                                    IMPLICIT
+                                                                    STRONG
+                                                                    COLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
 
 configure_file(2d_advection_implicit_strong.prm 2d_advection_implicit_strong.prm COPYONLY)
 add_test(
@@ -49,6 +109,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_implicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTION_IMPLICIT
+                                                                    2D
+                                                                    SERIAL
+                                                                    ADVECTION
+                                                                    IMPLICIT
+                                                                    STRONG
+                                                                    COLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
 
 configure_file(3d_advection_implicit_strong.prm 3d_advection_implicit_strong.prm COPYONLY)
 add_test(
@@ -56,6 +126,16 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_advection_implicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG_MEDIUM  ADVECTION_IMPLICIT
+                                                                                3D
+                                                                                PARALLEL
+                                                                                ADVECTION
+                                                                                IMPLICIT
+                                                                                STRONG
+                                                                                COLLOCATED
+                                                                                MANUFACTURED_SOLUTION
+                                                                                QUICK
+                                                                                INTEGRATION_TEST)
 
 configure_file(1d_advection_implicit_collocated.prm 1d_advection_implicit_collocated.prm COPYONLY)
 add_test(
@@ -63,13 +143,32 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_advection_implicit_collocated.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(1D_ADVECTION_IMPLICIT_COLLOCATED_MANUFACTURED_SOLUTION ADVECTION_IMPLICIT
+                                                                        1D
+                                                                        SERIAL
+                                                                        ADVECTION
+                                                                        IMPLICIT
+                                                                        WEAK
+                                                                        COLLOCATED
+                                                                        MANUFACTURED_SOLUTION
+                                                                        QUICK
+                                                                        INTEGRATION_TEST)
 configure_file(1d_advection_explicit_strong.prm 1d_advection_explicit_strong.prm COPYONLY)
 add_test(
   NAME 1D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_LONG_STRONG
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_advection_explicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_LONG_STRONG    ADVECTION_IMPLICIT
+                                                                            1D
+                                                                            SERIAL
+                                                                            ADVECTION
+                                                                            RUNGE-KUTTA
+                                                                            STRONG
+                                                                            COLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            MODERATE
+                                                                            INTEGRATION_TEST)
 
 configure_file(2d_advection_explicit_strong.prm 2d_advection_explicit_strong.prm COPYONLY)
 add_test(
@@ -77,6 +176,16 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_explicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_STRONG_LONG    ADVECTION_IMPLICIT
+                                                                                2D
+                                                                                PARALLEL
+                                                                                ADVECTION
+                                                                                RUNGE-KUTTA
+                                                                                STRONG
+                                                                                COLLOCATED
+                                                                                MANUFACTURED_SOLUTION
+                                                                                MODERATE
+                                                                                INTEGRATION_TEST)
 
 configure_file(3d_advection_explicit_strong.prm 3d_advection_explicit_strong.prm COPYONLY)
 add_test(
@@ -84,4 +193,13 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_advection_explicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_3D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTION_IMPLICIT
+                                                                        3D
+                                                                        PARALLEL
+                                                                        ADVECTION
+                                                                        RUNGE-KUTTA
+                                                                        STRONG
+                                                                        COLLOCATED
+                                                                        MANUFACTURED_SOLUTION
+                                                                        LONG
+                                                                        INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/advection_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_implicit/CMakeLists.txt
@@ -12,7 +12,7 @@ set_tests_labels(1D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLIC
                                                                 ADVECTION
                                                                 IMPLICIT
                                                                 WEAK
-                                                                COLLOCATED
+                                                                UNCOLLOCATED
                                                                 MANUFACTURED_SOLUTION
                                                                 QUICK
                                                                 INTEGRATION_TEST)
@@ -29,7 +29,7 @@ set_tests_labels(2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IMPLIC
                                                                 ADVECTION
                                                                 IMPLICIT
                                                                 WEAK
-                                                                COLLOCATED
+                                                                UNCOLLOCATED
                                                                 MANUFACTURED_SOLUTION
                                                                 MODERATE
                                                                 INTEGRATION_TEST)
@@ -46,7 +46,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_LONG   ADVECTIO
                                                                         ADVECTION
                                                                         RUNGE-KUTTA
                                                                         WEAK
-                                                                        COLLOCATED
+                                                                        UNCOLLOCATED
                                                                         MANUFACTURED_SOLUTION
                                                                         LONG
                                                                         INTEGRATION_TEST)
@@ -63,7 +63,7 @@ set_tests_labels(MPI_2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IM
                                                                     ADVECTION
                                                                     IMPLICIT
                                                                     WEAK
-                                                                    COLLOCATED
+                                                                    UNCOLLOCATED
                                                                     MANUFACTURED_SOLUTION
                                                                     QUICK
                                                                     INTEGRATION_TEST)
@@ -80,7 +80,7 @@ set_tests_labels(MPI_3D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION    ADVECTION_IM
                                                                     ADVECTION
                                                                     IMPLICIT
                                                                     WEAK
-                                                                    COLLOCATED
+                                                                    UNCOLLOCATED
                                                                     MANUFACTURED_SOLUTION
                                                                     MODERATE
                                                                     INTEGRATION_TEST)
@@ -98,7 +98,7 @@ set_tests_labels(1D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTION_IM
                                                                     ADVECTION
                                                                     IMPLICIT
                                                                     STRONG
-                                                                    COLLOCATED
+                                                                    UNCOLLOCATED
                                                                     MANUFACTURED_SOLUTION
                                                                     QUICK
                                                                     INTEGRATION_TEST)
@@ -115,7 +115,7 @@ set_tests_labels(2D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTION_IM
                                                                     ADVECTION
                                                                     IMPLICIT
                                                                     STRONG
-                                                                    COLLOCATED
+                                                                    UNCOLLOCATED
                                                                     MANUFACTURED_SOLUTION
                                                                     QUICK
                                                                     INTEGRATION_TEST)
@@ -132,7 +132,7 @@ set_tests_labels(MPI_3D_ADVECTION_IMPLICIT_MANUFACTURED_SOLUTION_STRONG_MEDIUM  
                                                                                 ADVECTION
                                                                                 IMPLICIT
                                                                                 STRONG
-                                                                                COLLOCATED
+                                                                                UNCOLLOCATED
                                                                                 MANUFACTURED_SOLUTION
                                                                                 QUICK
                                                                                 INTEGRATION_TEST)
@@ -165,7 +165,7 @@ set_tests_labels(1D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_LONG_STRONG    ADVE
                                                                             ADVECTION
                                                                             RUNGE-KUTTA
                                                                             STRONG
-                                                                            COLLOCATED
+                                                                            UNCOLLOCATED
                                                                             MANUFACTURED_SOLUTION
                                                                             MODERATE
                                                                             INTEGRATION_TEST)
@@ -182,7 +182,7 @@ set_tests_labels(MPI_2D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_STRONG_LONG    
                                                                                 ADVECTION
                                                                                 RUNGE-KUTTA
                                                                                 STRONG
-                                                                                COLLOCATED
+                                                                                UNCOLLOCATED
                                                                                 MANUFACTURED_SOLUTION
                                                                                 MODERATE
                                                                                 INTEGRATION_TEST)
@@ -199,7 +199,7 @@ set_tests_labels(MPI_3D_ADVECTION_EXPLICIT_MANUFACTURED_SOLUTION_STRONG ADVECTIO
                                                                         ADVECTION
                                                                         RUNGE-KUTTA
                                                                         STRONG
-                                                                        COLLOCATED
+                                                                        UNCOLLOCATED
                                                                         MANUFACTURED_SOLUTION
                                                                         LONG
                                                                         INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/advection_limiter/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_limiter/CMakeLists.txt
@@ -5,6 +5,16 @@ add_test(
  COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_advection_limiter.prm
  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_Advection_Limiter_Test  ADVECTION_LIMITER
+                                            1D
+                                            SERIAL
+                                            ADVECTION
+                                            RUNGE-KUTTA
+                                            STRONG
+                                            COLLOCATED
+                                            LIMITER
+                                            QUICK
+                                            INTEGRATION_TEST)
 
 #configure_file(1D_advection_limiter_OOA.prm 1D_advection_limiter_OOA.prm COPYONLY)
 #add_test(
@@ -26,7 +36,16 @@ add_test(
  COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_advection_limiter.prm
  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(2D_Advection_Limiter_Test  ADVECTION_LIMITER
+                                            2D
+                                            SERIAL
+                                            ADVECTION
+                                            RUNGE-KUTTA
+                                            STRONG
+                                            COLLOCATED
+                                            LIMITER
+                                            QUICK
+                                            INTEGRATION_TEST)
 #configure_file(2D_advection_limiter_OOA.prm 2D_advection_limiter_OOA.prm COPYONLY)
 #add_test(
 # NAME 2D_Advection_Limiter_OOA_Test

--- a/tests/integration_tests_control_files/advection_limiter/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_limiter/CMakeLists.txt
@@ -10,7 +10,7 @@ set_tests_labels(1D_Advection_Limiter_Test  ADVECTION_LIMITER
                                             SERIAL
                                             ADVECTION
                                             RUNGE-KUTTA
-                                            STRONG
+                                            STRONG-SPLIT
                                             COLLOCATED
                                             LIMITER
                                             QUICK

--- a/tests/integration_tests_control_files/advection_vector_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/advection_vector_implicit/CMakeLists.txt
@@ -6,13 +6,32 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_advection_vector_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(1D_ADVECTION_VECTOR_VALUED_IMPLICIT_MANUFACTURED_SOLUTION  ADVECTION_VECTOR_IMPLICIT
+                                                                            1D
+                                                                            SERIAL
+                                                                            ADVECTION
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            COLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            QUICK
+                                                                            INTEGRATION_TEST)
 configure_file(2d_advection_vector_implicit.prm 2d_advection_vector_implicit.prm COPYONLY)
 add_test(
   NAME 2D_ADVECTION_VECTOR_VALUED_IMPLICIT_MANUFACTURED_SOLUTION
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_advection_vector_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_ADVECTION_VECTOR_VALUED_IMPLICIT_MANUFACTURED_SOLUTION  ADVECTION_VECTOR_IMPLICIT
+                                                                            2D
+                                                                            SERIAL
+                                                                            ADVECTION
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            COLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            QUICK
+                                                                            INTEGRATION_TEST)
 
 configure_file(3d_advection_vector_implicit.prm 3d_advection_vector_implicit.prm COPYONLY)
 add_test(
@@ -20,3 +39,13 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_advection_vector_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_ADVECTION_VECTOR_VALUED_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM   ADVECTION_VECTOR_IMPLICIT
+                                                                                        3D
+                                                                                        PARALLEL
+                                                                                        ADVECTION
+                                                                                        IMPLICIT
+                                                                                        WEAK
+                                                                                        COLLOCATED
+                                                                                        MANUFACTURED_SOLUTION
+                                                                                        QUICK
+                                                                                        INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/burgers_inviscid_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/burgers_inviscid_implicit/CMakeLists.txt
@@ -6,6 +6,15 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_burgers_inviscid_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_BURGERS_INVISCID_IMPLICIT_MANUFACTURED_SOLUTION BURGERS_INVISCID_IMPLICIT
+                                                                    1D
+                                                                    SERIAL
+                                                                    BURGERS_INVISCID
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
 
 configure_file(1d_burgers_inviscid_implicit_collocated.prm 1d_burgers_inviscid_implicit_collocated.prm COPYONLY)
 add_test(
@@ -13,7 +22,15 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_burgers_inviscid_implicit_collocated.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(1D_BURGERS_INVISCID_IMPLICIT_COLLOCATED_MANUFACTURED_SOLUTION  BURGERS_INVISCID_IMPLICIT
+                                                                                1D
+                                                                                SERIAL
+                                                                                BURGERS_INVISCID
+                                                                                IMPLICIT
+                                                                                WEAK
+                                                                                UNCOLLOCATED
+                                                                                QUICK
+                                                                                INTEGRATION_TEST)
 
 # configure_file(2d_burgers_inviscid_implicit.prm 2d_burgers_inviscid_implicit.prm COPYONLY)
 # add_test(

--- a/tests/integration_tests_control_files/burgers_limiter/CMakeLists.txt
+++ b/tests/integration_tests_control_files/burgers_limiter/CMakeLists.txt
@@ -5,7 +5,15 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_burgers_limiter.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(1D_Burgers_Limiter_Test    BURGERS_LIMITER
+                                            1D
+                                            SERIAL
+                                            BURGERS_INVISCID
+                                            RUNGE-KUTTA
+                                            STRONG
+                                            COLLOCATED
+                                            QUICK
+                                            INTEGRATION_TEST)
 #configure_file(1D_burgers_limiter_OOA.prm 1D_burgers_limiter_OOA.prm COPYONLY)
 #add_test(
 #  NAME 1D_Burgers_Limiter_OOA_Test
@@ -26,7 +34,15 @@ add_test(
    COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_burgers_limiter.prm
    WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(2D_Burgers_Limiter_Test    BURGERS_LIMITER
+                                            2D
+                                            SERIAL
+                                            BURGERS_INVISCID
+                                            RUNGE-KUTTA
+                                            STRONG
+                                            COLLOCATED
+                                            QUICK
+                                            INTEGRATION_TEST)
 #configure_file(2D_burgers_limiter_OOA.prm 2D_burgers_limiter_OOA.prm COPYONLY)
 #add_test(
 #  NAME 2D_Burgers_Limiter_OOA_Test

--- a/tests/integration_tests_control_files/burgers_split_stability/CMakeLists.txt
+++ b/tests/integration_tests_control_files/burgers_split_stability/CMakeLists.txt
@@ -5,6 +5,15 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_burgers_stability_energy.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_BURGERS_STABILITY_ENERGY_LONG   BURGERS_SPLIT_STABILITY
+                                                    1D
+                                                    SERIAL
+                                                    BURGERS_INVISCID
+                                                    RUNGE-KUTTA
+                                                    STRONG-SPLIT
+                                                    UNCOLLOCATED
+                                                    MODERATE
+                                                    INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(1D_burgers_stability_OOA.prm 1D_burgers_stability_OOA.prm COPYONLY)
 add_test(
@@ -12,4 +21,12 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_burgers_stability_OOA.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(1D_BURGERS_STABILITY_ORDERS_OF_ACCURACY_LONG   BURGERS_SPLIT_STABILITY
+                                                                1D
+                                                                SERIAL
+                                                                BURGERS_INVISCID
+                                                                RUNGE-KUTTA
+                                                                STRONG-SPLIT
+                                                                UNCOLLOCATED
+                                                                QUICK
+                                                                INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/convection_diffusion_explicit_periodic/CMakeLists.txt
+++ b/tests/integration_tests_control_files/convection_diffusion_explicit_periodic/CMakeLists.txt
@@ -5,6 +5,15 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_conv_diff_explicit_periodic_energy.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_CONVECTION_DIFFUSION_EXPLICIT_PERIODIC_ENERGY_LONG  CONVECTION_DIFFUSION_EXPLICIT_PERIODIC
+                                                                            2D
+                                                                            PARALLEL
+                                                                            DIFFUSION
+                                                                            RUNGE-KUTTA
+                                                                            STRONG
+                                                                            UNCOLLOCATED
+                                                                            MODERATE
+                                                                            INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(2D_conv_diff_explicit_periodic_OOA.prm 2D_conv_diff_explicit_periodic_OOA.prm COPYONLY)
 add_test(
@@ -12,6 +21,15 @@ add_test(
 COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2D_conv_diff_explicit_periodic_OOA.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_CONVECTION_DIFFUSION_EXPLICIT_PERIODIC_OOA_LONG CONVECTION_DIFFUSION_EXPLICIT_PERIODIC
+                                                                        2D
+                                                                        PARALLEL
+                                                                        DIFFUSION
+                                                                        RUNGE-KUTTA
+                                                                        STRONG
+                                                                        UNCOLLOCATED
+                                                                        LONG
+                                                                        INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(1D_conv_diff_explicit_periodic_energy.prm 1D_conv_diff_explicit_periodic_energy.prm COPYONLY)
 add_test(
@@ -19,3 +37,12 @@ add_test(
 COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_conv_diff_explicit_periodic_energy.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_CONVECTION_DIFFUSION_EXPLICIT_PERIODIC_ENERGY_LONG  CONVECTION_DIFFUSION_EXPLICIT_PERIODIC
+                                                                        1D
+                                                                        SERIAL
+                                                                        DIFFUSION
+                                                                        RUNGE-KUTTA
+                                                                        STRONG
+                                                                        UNCOLLOCATED
+                                                                        QUICK
+                                                                        INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/convection_diffusion_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/convection_diffusion_implicit/CMakeLists.txt
@@ -6,6 +6,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_convection_diffusion_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_CONVECTION_DIFFUSION_IMPLICIT_MANUFACTURED_SOLUTION CONVECTION_DIFFUSION_IMPLICIT
+                                                                        1D
+                                                                        SERIAL
+                                                                        CONVECTION_DIFFUSION
+                                                                        IMPLICIT
+                                                                        WEAK
+                                                                        UNCOLLOCATED
+                                                                        MANUFACTURED_SOLUTION
+                                                                        QUICK
+                                                                        INTEGRATION_TEST)
 
 configure_file(2d_convection_diffusion_implicit.prm 2d_convection_diffusion_implicit.prm COPYONLY)
 add_test(
@@ -13,6 +23,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_convection_diffusion_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_CONVECTION_DIFFUSION_IMPLICIT_MANUFACTURED_SOLUTION CONVECTION_DIFFUSION_IMPLICIT
+                                                                        2D
+                                                                        SERIAL
+                                                                        CONVECTION_DIFFUSION
+                                                                        IMPLICIT
+                                                                        WEAK
+                                                                        UNCOLLOCATED
+                                                                        MANUFACTURED_SOLUTION
+                                                                        QUICK
+                                                                        INTEGRATION_TEST)
 
 configure_file(2d_convection_diffusion_implicit_collocated.prm 2d_convection_diffusion_implicit_collocated.prm COPYONLY)
 add_test(
@@ -20,6 +40,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_convection_diffusion_implicit_collocated.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_CONVECTION_DIFFUSION_IMPLICIT_COLLOCATED_MANUFACTURED_SOLUTION  CONVECTION_DIFFUSION_IMPLICIT
+                                                                                    2D
+                                                                                    SERIAL
+                                                                                    CONVECTION_DIFFUSION
+                                                                                    IMPLICIT
+                                                                                    WEAK
+                                                                                    COLLOCATED
+                                                                                    MANUFACTURED_SOLUTION
+                                                                                    QUICK
+                                                                                    INTEGRATION_TEST)
 
 configure_file(3d_convection_diffusion_implicit.prm 3d_convection_diffusion_implicit.prm COPYONLY)
 add_test(
@@ -27,3 +57,13 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_convection_diffusion_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_CONVECTION_DIFFUSION_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM  CONVECTION_DIFFUSION_IMPLICIT
+                                                                                    3D
+                                                                                    PARALLEL
+                                                                                    CONVECTION_DIFFUSION
+                                                                                    IMPLICIT
+                                                                                    WEAK
+                                                                                    UNCOLLOCATED
+                                                                                    MANUFACTURED_SOLUTION
+                                                                                    QUICK
+                                                                                    INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/CMakeLists.txt
+++ b/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/CMakeLists.txt
@@ -12,9 +12,29 @@ configure_file(dhit_init_check_serial.prm dhit_init_check_serial.prm COPYONLY)
 add_test(NAME SERIAL_DHIT_INIT_CHECK
          COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/dhit_init_check_serial.prm
          WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
+set_tests_labels(SERIAL_DHIT_INIT_CHECK DECAYING_HOMOGENEOUS_ISOTROPIC_TURBULENCE
+                                        3D
+                                        SERIAL
+                                        NAVIER-STOKES
+                                        RUNGE-KUTTA
+                                        STRONG
+                                        COLLOCATED
+                                        CONVERGENCE
+                                        QUICK
+                                        INTEGRATION_TEST)
 # ----------------------------------------
 configure_file(dhit_init_check_mpi.prm dhit_init_check_mpi.prm COPYONLY)
 add_test(NAME MPI_DHIT_INIT_CHECK
          COMMAND mpirun -np 4 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/dhit_init_check_mpi.prm
          WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
+set_tests_labels(MPI_DHIT_INIT_CHECK    DECAYING_HOMOGENEOUS_ISOTROPIC_TURBULENCE
+                                        3D
+                                        PARALLEL
+                                        NAVIER-STOKES
+                                        RUNGE-KUTTA
+                                        STRONG
+                                        COLLOCATED
+                                        CONVERGENCE
+                                        QUICK
+                                        INTEGRATION_TEST)
 # ----------------------------------------

--- a/tests/integration_tests_control_files/diffusion_implicit/CMakeLists.txt
+++ b/tests/integration_tests_control_files/diffusion_implicit/CMakeLists.txt
@@ -6,18 +6,50 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_diffusion_sipg_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_DIFFUSION_SIPG_IMPLICIT_MANUFACTURED_SOLUTION   DIFFUSION_IMPLICIT
+                                                                    1D
+                                                                    SERIAL
+                                                                    DIFFUSION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
+
 configure_file(2d_diffusion_sipg_implicit.prm 2d_diffusion_sipg_implicit.prm COPYONLY)
 add_test(
   NAME 2D_DIFFUSION_SIPG_IMPLICIT_MANUFACTURED_SOLUTION
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_diffusion_sipg_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_DIFFUSION_SIPG_IMPLICIT_MANUFACTURED_SOLUTION   DIFFUSION_IMPLICIT
+                                                                    2D
+                                                                    SERIAL
+                                                                    DIFFUSION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
+
 configure_file(3d_diffusion_sipg_implicit.prm 3d_diffusion_sipg_implicit.prm COPYONLY)
 add_test(
   NAME MPI_3D_DIFFUSION_SIPG_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_diffusion_sipg_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_DIFFUSION_SIPG_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM    DIFFUSION_IMPLICIT
+                                                                                3D
+                                                                                PARALLEL
+                                                                                DIFFUSION
+                                                                                IMPLICIT
+                                                                                WEAK
+                                                                                UNCOLLOCATED
+                                                                                MANUFACTURED_SOLUTION
+                                                                                MODERATE
+                                                                                INTEGRATION_TEST)
 
 configure_file(1d_diffusion_br2_implicit.prm 1d_diffusion_br2_implicit.prm COPYONLY)
 add_test(
@@ -25,6 +57,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_diffusion_br2_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_DIFFUSION_BR2_IMPLICIT_MANUFACTURED_SOLUTION    DIFFUSION_IMPLICIT
+                                                                    1D
+                                                                    SERIAL
+                                                                    DIFFUSION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
 
 configure_file(1d_diffusion_sipg_explicit_strong.prm 1d_diffusion_sipg_explicit_strong.prm COPYONLY)
 add_test(
@@ -32,18 +74,50 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_diffusion_sipg_explicit_strong.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_DIFFUSION_SIPG_EXPLICIT_MANUFACTURED_SOLUTION_STRONG_LONG   DIFFUSION_IMPLICIT
+                                                                                1D
+                                                                                SERIAL
+                                                                                DIFFUSION
+                                                                                RUNGE-KUTTA
+                                                                                STRONG
+                                                                                UNCOLLOCATED
+                                                                                MANUFACTURED_SOLUTION
+                                                                                LONG
+                                                                                INTEGRATION_TEST)
+
 configure_file(2d_diffusion_br2_implicit.prm 2d_diffusion_br2_implicit.prm COPYONLY)
 add_test(
   NAME 2D_DIFFUSION_BR2_IMPLICIT_MANUFACTURED_SOLUTION
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_diffusion_br2_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_DIFFUSION_BR2_IMPLICIT_MANUFACTURED_SOLUTION    DIFFUSION_IMPLICIT
+                                                                    2D
+                                                                    PARALLEL
+                                                                    DIFFUSION
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    QUICK
+                                                                    INTEGRATION_TEST)
+
 configure_file(3d_diffusion_br2_implicit.prm 3d_diffusion_br2_implicit.prm COPYONLY)
 add_test(
   NAME MPI_3D_DIFFUSION_BR2_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_diffusion_br2_implicit.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_DIFFUSION_BR2_IMPLICIT_MANUFACTURED_SOLUTION_MEDIUM DIFFUSION_IMPLICIT
+                                                                            3D
+                                                                            PARALLEL
+                                                                            DIFFUSION
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            UNCOLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            MODERATE
+                                                                            INTEGRATION_TEST)
 
 # Adjoint test case
 configure_file(1d_diffusion_exact_adjoint.prm 1d_diffusion_exact_adjoint.prm COPYONLY)
@@ -52,6 +126,16 @@ add_test(
   COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_diffusion_exact_adjoint.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_DIFFUSION_EXACT_ADJOINT DIFFUSION_IMPLICIT
+                                            1D
+                                            SERIAL
+                                            DIFFUSION
+                                            IMPLICIT
+                                            WEAK
+                                            UNCOLLOCATED
+                                            ADJOINT
+                                            MODERATE
+                                            INTEGRATION_TEST)
 
 configure_file(2d_diffusion_exact_adjoint.prm 2d_diffusion_exact_adjoint.prm COPYONLY)
 add_test(
@@ -59,6 +143,16 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_diffusion_exact_adjoint.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_DIFFUSION_EXACT_ADJOINT DIFFUSION_IMPLICIT
+                                            2D
+                                            PARALLEL
+                                            DIFFUSION
+                                            IMPLICIT
+                                            WEAK
+                                            UNCOLLOCATED
+                                            ADJOINT
+                                            MODERATE
+                                            INTEGRATION_TEST)
 
 configure_file(3d_diffusion_exact_adjoint.prm 3d_diffusion_exact_adjoint.prm COPYONLY)
 add_test(
@@ -66,3 +160,13 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_diffusion_exact_adjoint.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_DIFFUSION_EXACT_ADJOINT_LONG    DIFFUSION_IMPLICIT
+                                                    3D
+                                                    PARALLEL
+                                                    DIFFUSION
+                                                    IMPLICIT
+                                                    WEAK
+                                                    UNCOLLOCATED
+                                                    ADJOINT
+                                                    LONG
+                                                    INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/euler_bump_optimization/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_bump_optimization/CMakeLists.txt
@@ -6,3 +6,12 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_bump_optimization.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_BUMP_OPTIMIZATION EULER_BUMP_OPTIMIZATION
+                                            2D
+                                            PARALLEL
+                                            EULER
+                                            IMPLICIT
+                                            WEAK
+                                            UNCOLLOCATED
+                                            LONG
+                                            INTEGRATION_TEST)

--- a/tests/integration_tests_control_files/euler_entropy_conservation/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_entropy_conservation/CMakeLists.txt
@@ -14,6 +14,15 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/euler_entropy_conserving_split_forms_check.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_EULER_ENTROPY_CONSERVING_SPLIT_FORMS_CHECK  EULER_ENTROPY_CONSERVATION
+                                                                    3D
+                                                                    PARALLEL
+                                                                    EULER
+                                                                    RUNGE-KUTTA
+                                                                    STRONG-SPLIT
+                                                                    COLLOCATED
+                                                                    LONG
+                                                                    INTEGRATION_TEST)
 # ----------------------------------------
 
 # =======================================

--- a/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
@@ -11,6 +11,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_euler_laxfriedrichs_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_EULER_LAXFRIEDRICHS_MANUFACTURED_SOLUTION   EULER_INTEGRATION
+                                                                1D
+                                                                SERIAL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                QUICK
+                                                                INTEGRATION_TEST)
 
 configure_file(1d_euler_laxfriedrichs_manufactured_collocated.prm 1d_euler_laxfriedrichs_manufactured_collocated.prm COPYONLY)
 add_test(
@@ -18,6 +29,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_euler_laxfriedrichs_manufactured_collocated.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_EULER_LAXFRIEDRICHS_COLLOCATED_MANUFACTURED_SOLUTION    EULER_INTEGRATION
+                                                                            1D
+                                                                            SERIAL
+                                                                            EULER
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            COLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            CONVERGENCE
+                                                                            QUICK
+                                                                            INTEGRATION_TEST)
 
 configure_file(2d_euler_laxfriedrichs_manufactured.prm 2d_euler_laxfriedrichs_manufactured.prm COPYONLY)
 add_test(
@@ -25,6 +47,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_laxfriedrichs_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_LAXFRIEDRICHS_MANUFACTURED_SOLUTION_LONG  EULER_INTEGRATION
+                                                                    2D
+                                                                    SERIAL
+                                                                    EULER
+                                                                    IMPLICIT
+                                                                    WEAK
+                                                                    UNCOLLOCATED
+                                                                    MANUFACTURED_SOLUTION
+                                                                    CONVERGENCE
+                                                                    MODERATE
+                                                                    INTEGRATION_TEST)
 
 configure_file(2d_euler_laxfriedrichs_manufactured_collocated.prm 2d_euler_laxfriedrichs_manufactured_collocated.prm COPYONLY)
 add_test(
@@ -32,6 +65,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_laxfriedrichs_manufactured_collocated.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_LAXFRIEDRICHS_COLLOCATED_MANUFACTURED_SOLUTION    EULER_INTEGRATION
+                                                                            2D
+                                                                            SERIAL
+                                                                            EULER
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            COLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            CONVERGENCE
+                                                                            MODERATE
+                                                                            INTEGRATION_TEST)
 
 configure_file(2d_euler_laxfriedrichs_manufactured.prm 2d_euler_laxfriedrichs_manufactured.prm COPYONLY)
 add_test(
@@ -39,6 +83,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_laxfriedrichs_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_LAXFRIEDRICHS_MANUFACTURED_SOLUTION_MEDIUM    EULER_INTEGRATION
+                                                                            2D
+                                                                            PARALLEL
+                                                                            EULER
+                                                                            IMPLICIT
+                                                                            WEAK
+                                                                            UNCOLLOCATED
+                                                                            MANUFACTURED_SOLUTION
+                                                                            CONVERGENCE
+                                                                            MODERATE
+                                                                            INTEGRATION_TEST)
 
 configure_file(2d_euler_laxfriedrichs_manufactured_navah.prm 2d_euler_laxfriedrichs_manufactured_navah.prm COPYONLY)
 add_test(
@@ -46,6 +101,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_laxfriedrichs_manufactured_navah.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_LAXFRIEDRICHS_MANUFACTURED_SOLUTION_NAVAH_MEDIUM  EULER_INTEGRATION
+                                                                                2D
+                                                                                PARALLEL
+                                                                                EULER
+                                                                                IMPLICIT
+                                                                                WEAK
+                                                                                UNCOLLOCATED
+                                                                                MANUFACTURED_SOLUTION
+                                                                                CONVERGENCE
+                                                                                MODERATE
+                                                                                INTEGRATION_TEST)
 
 configure_file(1d_euler_roe_manufactured.prm 1d_euler_roe_manufactured.prm COPYONLY)
 add_test(
@@ -53,6 +119,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_euler_roe_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_EULER_ROE_MANUFACTURED_SOLUTION_LONG    EULER_INTEGRATION
+                                                            1D
+                                                            SERIAL
+                                                            EULER
+                                                            IMPLICIT
+                                                            WEAK
+                                                            UNCOLLOCATED
+                                                            MANUFACTURED_SOLUTION
+                                                            CONVERGENCE
+                                                            QUICK
+                                                            INTEGRATION_TEST)
 
 configure_file(1d_euler_l2roe_manufactured.prm 1d_euler_l2roe_manufactured.prm COPYONLY)
 add_test(
@@ -60,6 +137,17 @@ add_test(
   COMMAND mpirun -np 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1d_euler_l2roe_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(1D_EULER_L2ROE_MANUFACTURED_SOLUTION_LONG      EULER_INTEGRATION
+                                                                1D
+                                                                SERIAL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                QUICK
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_euler_roe_manufactured.prm 2d_euler_roe_manufactured.prm COPYONLY)
 add_test(
@@ -67,6 +155,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_roe_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_ROE_MANUFACTURED_SOLUTION_MEDIUM  EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                QUICK
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_euler_roe_manufactured_navah.prm 2d_euler_roe_manufactured_navah.prm COPYONLY)
 add_test(
@@ -74,6 +173,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_roe_manufactured_navah.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_ROE_MANUFACTURED_SOLUTION_MEDIUM  EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_euler_l2roe_manufactured.prm 2d_euler_l2roe_manufactured.prm COPYONLY)
 add_test(
@@ -81,6 +191,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_l2roe_manufactured.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_ROE_MANUFACTURED_SOLUTION_MEDIUM  EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_euler_l2roe_manufactured_navah.prm 2d_euler_l2roe_manufactured_navah.prm COPYONLY)
 add_test(
@@ -88,6 +209,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_l2roe_manufactured_navah.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_ROE_MANUFACTURED_SOLUTION_MEDIUM  EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 # Exact solutions
 
@@ -97,6 +229,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_cylinder.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_CYLINDER_LONG     EULER_INTEGRATION
+                                                            2D
+                                                            PARALLEL
+                                                            EULER
+                                                            IMPLICIT
+                                                            WEAK
+                                                            UNCOLLOCATED
+                                                            MANUFACTURED_SOLUTION
+                                                            CONVERGENCE
+                                                            LONG
+                                                            INTEGRATION_TEST)
 
 configure_file(2d_euler_gaussian_bump.prm 2d_euler_gaussian_bump.prm COPYONLY)
 add_test(
@@ -104,6 +247,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_LONG    EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 configure_file(3d_euler_gaussian_bump.prm 3d_euler_gaussian_bump.prm COPYONLY)
 add_test(
@@ -111,6 +265,15 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_euler_gaussian_bump.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_3D_EULER_INTEGRATION_GAUSSIAN_BUMP     EULER_INTEGRATION
+                                                            3D
+                                                            PARALLEL
+                                                            EULER
+                                                            IMPLICIT
+                                                            WEAK
+                                                            UNCOLLOCATED
+                                                            QUICK
+                                                            INTEGRATION_TEST)
 
 ##Artificial dissipation tests
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_residual_convergence_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_residual_convergence_test.prm COPYONLY)
@@ -119,44 +282,126 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_residual_convergence_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_LAPLACIAN_RESIDUAL_CONVERGENCE    EULER_INTEGRATION
+                                                                                                                    2D
+                                                                                                                    PARALLEL
+                                                                                                                    EULER
+                                                                                                                    IMPLICIT
+                                                                                                                    WEAK
+                                                                                                                    UNCOLLOCATED
+                                                                                                                    ARTIFICIAL_VISCOSITY
+                                                                                                                    MANUFACTURED_SOLUTION
+                                                                                                                    CONVERGENCE
+                                                                                                                    QUICK
+                                                                                                                    INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_residual_convergence_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_residual_convergence_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_ENTHALPY_LAPLACIAN_RESIDUAL_CONVERGENCE
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_residual_convergence_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_ENTHALPY_LAPLACIAN_RESIDUAL_CONVERGENCE   EULER_INTEGRATION
+                                                                                                                            2D
+                                                                                                                            PARALLEL
+                                                                                                                            EULER
+                                                                                                                            IMPLICIT
+                                                                                                                            WEAK
+                                                                                                                            UNCOLLOCATED
+                                                                                                                            ARTIFICIAL_VISCOSITY
+                                                                                                                            MANUFACTURED_SOLUTION
+                                                                                                                            CONVERGENCE
+                                                                                                                            QUICK
+                                                                                                                            INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_physical_residual_convergence_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_physical_residual_convergence_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_PHYSICAL_RESIDUAL_CONVERGENCE
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_physical_residual_convergence_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_PHYSICAL_RESIDUAL_CONVERGENCE EULER_INTEGRATION
+                                                                                                                2D
+                                                                                                                PARALLEL
+                                                                                                                EULER
+                                                                                                                IMPLICIT
+                                                                                                                WEAK
+                                                                                                                UNCOLLOCATED
+                                                                                                                ARTIFICIAL_VISCOSITY
+                                                                                                                MANUFACTURED_SOLUTION
+                                                                                                                CONVERGENCE
+                                                                                                                QUICK
+                                                                                                                INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_discontinuity_sensor_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_discontinuity_sensor_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_LAPLACIAN_DISCONTINUITY_SENSOR
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_laplacian_discontinuity_sensor_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_LAPLACIAN_DISCONTINUITY_SENSOR    EULER_INTEGRATION
+                                                                                                                    2D
+                                                                                                                    PARALLEL
+                                                                                                                    EULER
+                                                                                                                    IMPLICIT
+                                                                                                                    WEAK
+                                                                                                                    UNCOLLOCATED
+                                                                                                                    ARTIFICIAL_VISCOSITY
+                                                                                                                    MANUFACTURED_SOLUTION
+                                                                                                                    CONVERGENCE
+                                                                                                                    QUICK
+                                                                                                                    INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_discontinuity_sensor_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_discontinuity_sensor_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_ENTHALPY_LAPLACIAN_DISCONTINUITY_SENSOR
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_enthalpy_laplacian_discontinuity_sensor_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_ENTHALPY_LAPLACIAN_DISCONTINUITY_SENSOR   EULER_INTEGRATION
+                                                                                                                            2D
+                                                                                                                            PARALLEL
+                                                                                                                            EULER
+                                                                                                                            IMPLICIT
+                                                                                                                            WEAK
+                                                                                                                            UNCOLLOCATED
+                                                                                                                            ARTIFICIAL_VISCOSITY
+                                                                                                                            MANUFACTURED_SOLUTION
+                                                                                                                            CONVERGENCE
+                                                                                                                            QUICK
+                                                                                                                            INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_with_artificial_dissipation_physical_discontinuity_sensor_test.prm 2d_euler_gaussian_bump_with_artificial_dissipation_physical_discontinuity_sensor_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_PHYSICAL_DISCONTINUITY_SENSOR
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_with_artificial_dissipation_physical_discontinuity_sensor_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_WITH_ARTIFICIAL_VISCOSITY_PHYSICAL_DISCONTINUITY_SENSOR EULER_INTEGRATION
+                                                                                                                2D
+                                                                                                                PARALLEL
+                                                                                                                EULER
+                                                                                                                IMPLICIT
+                                                                                                                WEAK
+                                                                                                                UNCOLLOCATED
+                                                                                                                ARTIFICIAL_VISCOSITY
+                                                                                                                MANUFACTURED_SOLUTION
+                                                                                                                CONVERGENCE
+                                                                                                                QUICK
+                                                                                                                INTEGRATION_TEST)
 configure_file(2d_euler_gaussian_bump_enthalpy_test.prm 2d_euler_gaussian_bump_enthalpy_test.prm COPYONLY)
 add_test(
   NAME MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_ENTHALPY_TEST
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_enthalpy_test.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_ENTHALPY_TEST   EULER_INTEGRATION
+                                                                        2D
+                                                                        PARALLEL
+                                                                        EULER
+                                                                        IMPLICIT
+                                                                        WEAK
+                                                                        UNCOLLOCATED
+                                                                        ARTIFICIAL_VISCOSITY
+                                                                        MANUFACTURED_SOLUTION
+                                                                        CONVERGENCE
+                                                                        QUICK
+                                                                        INTEGRATION_TEST)
 # Mesh Adaptation test cases
 configure_file(2d_euler_gaussian_bump_residual_mesh_adaptation.prm 2d_euler_gaussian_bump_residual_mesh_adaptation.prm COPYONLY)
 add_test(
@@ -164,6 +409,18 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_gaussian_bump_residual_mesh_adaptation.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(MPI_2D_EULER_INTEGRATION_GAUSSIAN_BUMP_RESIDUAL_MESH_ADAPTATION    EULER_INTEGRATION
+                                                                                    2D
+                                                                                    PARALLEL
+                                                                                    EULER
+                                                                                    IMPLICIT
+                                                                                    WEAK
+                                                                                    UNCOLLOCATED
+                                                                                    ARTIFICIAL_VISCOSITY
+                                                                                    MANUFACTURED_SOLUTION
+                                                                                    CONVERGENCE
+                                                                                    QUICK
+                                                                                    INTEGRATION_TEST)
 # Adjoint test cases
 
 # configure_file(2d_euler_gaussian_bump_adjoint.prm 2d_euler_gaussian_bump_adjoint.prm COPYONLY)
@@ -181,7 +438,17 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_cylinder_adjoint.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(MPI_2D_EULER_INTEGRATION_CYLINDER_ADJOINT_LONG EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                MODERATE
+                                                                INTEGRATION_TEST)
 
 # Vortex test case takes wayyy too much time. It works, so uncomment below if you want to wait.
 # configure_file(2d_euler_vortex.prm 2d_euler_vortex.prm COPYONLY)

--- a/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/naca0012/CMakeLists.txt
@@ -4,6 +4,18 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_naca0012_subsonic_05_200.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_INTEGRATION_NACA0012_SUBSONIC_LONG    EULER_INTEGRATION
+                                                                NACA0012
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                LONG
+                                                                INTEGRATION_TEST)
 
 configure_file(2d_euler_naca0012_transonic_08_125.prm 2d_euler_naca0012_transonic_08_125.prm COPYONLY)
 add_test(
@@ -11,6 +23,18 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_naca0012_transonic_08_125.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_INTEGRATION_NACA0012_TRANSONIC_LONG   EULER_INTEGRATION
+                                                                NACA0012
+                                                                2D
+                                                                PARALLEL
+                                                                EULER
+                                                                IMPLICIT
+                                                                WEAK
+                                                                UNCOLLOCATED
+                                                                MANUFACTURED_SOLUTION
+                                                                CONVERGENCE
+                                                                LONG
+                                                                INTEGRATION_TEST)
 
 configure_file(inviscid_transonic_steady_state_naca0012.prm inviscid_transonic_steady_state_naca0012.prm COPYONLY)
 add_test(
@@ -18,6 +42,16 @@ add_test(
         COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/inviscid_transonic_steady_state_naca0012.prm
         WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(INVISCID_TRANSONIC_STEADY_STATE_NACA0012   EULER_INTEGRATION
+                                                            NACA0012
+                                                            2D
+                                                            PARALLEL
+                                                            EULER
+                                                            IMPLICIT
+                                                            WEAK
+                                                            UNCOLLOCATED
+                                                            QUICK
+                                                            INTEGRATION_TEST)
 
 configure_file(2d_euler_transonic_naca0012_drag_based_grid_adaptation.prm 2d_euler_transonic_naca0012_drag_based_grid_adaptation.prm COPYONLY)
 add_test(
@@ -25,6 +59,17 @@ add_test(
         COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_transonic_naca0012_drag_based_grid_adaptation.prm
         WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(INVISCID_TRANSONIC_STEADY_STATE_NACA0012_DRAG_BASED_GRID_ADAPTATION    EULER_INTEGRATION
+                                                                                        NACA0012
+                                                                                        2D
+                                                                                        PARALLEL
+                                                                                        EULER
+                                                                                        IMPLICIT
+                                                                                        WEAK
+                                                                                        UNCOLLOCATED
+                                                                                        MESH_ADAPTATION
+                                                                                        MODERATE
+                                                                                        INTEGRATION_TEST)
 
 configure_file(2d_euler_subsonic_naca0012_lift_based_hp_adaptation.prm  2d_euler_subsonic_naca0012_lift_based_hp_adaptation.prm  COPYONLY)
 add_test(
@@ -32,6 +77,17 @@ add_test(
         COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_subsonic_naca0012_lift_based_hp_adaptation.prm 
         WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(INVISCID_SUBSONIC_NACA0012_LIFT_BASED_HP_ADAPTATION    EULER_INTEGRATION
+                                                                        NACA0012
+                                                                        2D
+                                                                        PARALLEL
+                                                                        EULER
+                                                                        IMPLICIT
+                                                                        WEAK
+                                                                        UNCOLLOCATED
+                                                                        MESH_ADAPTATION
+                                                                        MODERATE
+                                                                        INTEGRATION_TEST)
 
 configure_file(naca0012_unsteady.prm naca0012_unsteady.prm COPYONLY)
 add_test(
@@ -39,6 +95,16 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/naca0012_unsteady.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_INTEGRATION_UNSTEADY_NACA0012_SUBSONIC_STRONGvWEAK    EULER_INTEGRATION
+                                                                                NACA0012
+                                                                                2D
+                                                                                PARALLEL
+                                                                                EULER
+                                                                                RUNGE-KUTTA
+                                                                                WEAK STRONG
+                                                                                UNCOLLOCATED
+                                                                                MODERATE
+                                                                                INTEGRATION_TEST)
 
 #configure_file(2d_navier_stokes_naca0012_subsonic_05_200.prm 2d_navier_stokes_naca0012_subsonic_05_200.prm COPYONLY)
 #add_test(

--- a/tests/integration_tests_control_files/euler_naca_optimization/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_naca_optimization/CMakeLists.txt
@@ -7,3 +7,15 @@ add_test(
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_euler_naca_optimization.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_EULER_NACA0012_OPTIMIZATION EULER_ENTROPY_CONSERVATION
+                                                2D
+                                                PARALLEL
+                                                EULER
+                                                IMPLICIT
+                                                WEAK
+                                                UNCOLLOCATED
+                                                MANUFACTURED_SOLUTION
+                                                CONVERGENCE
+                                                LONG
+                                                INTEGRATION_TEST)
+

--- a/tests/integration_tests_control_files/euler_split_inviscid_taylor_green_vortex/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_split_inviscid_taylor_green_vortex/CMakeLists.txt
@@ -4,7 +4,16 @@ add_test(
  NAME MPI_3D_EULER_SPLIT_TAYLOR_GREEN                                                                                                                                                                                    
  COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_euler_split_inviscid_taylor_green_vortex.prm                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
-)                                                                                                                       
+)
+set_tests_labels(MPI_3D_EULER_SPLIT_TAYLOR_GREEN    EULER_INTEGRATION
+                                                    3D
+                                                    PARALLEL
+                                                    EULER
+                                                    RUNGE-KUTTA
+                                                    STRONG-SPLIT
+                                                    UNCOLLOCATED
+                                                    LONG
+                                                    INTEGRATION_TEST)
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})                                                                     
 configure_file(3D_euler_split_inviscid_taylor_green_vortex_curv.prm 3D_euler_split_inviscid_taylor_green_vortex_curv.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
@@ -12,3 +21,13 @@ add_test(
  COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_euler_split_inviscid_taylor_green_vortex_curv.prm                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )                                                                                                                       
+set_tests_labels(MPI_3D_EULER_SPLIT_TAYLOR_GREEN_CURV   EULER_INTEGRATION
+                                                        3D
+                                                        PARALLEL
+                                                        EULER
+                                                        RUNGE-KUTTA
+                                                        STRONG-SPLIT
+                                                        UNCOLLOCATED
+                                                        CURVILINEAR
+                                                        LONG
+                                                        INTEGRATION_TEST)

--- a/tests/unit_tests/euler_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/euler_unit_test/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${TEST_TARGET} ${dim}D EULER_UNIT_TEST QUICK SERIAL UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -64,6 +65,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D MANUFACTURED_SOURCE SERIAL QUICK UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -100,7 +102,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -140,6 +142,7 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D QUICK SERIAL UNIT_TEST)
 
     unset(TEST_TARGET)
 

--- a/tests/unit_tests/euler_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/euler_unit_test/CMakeLists.txt
@@ -28,7 +28,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D EULER_UNIT_TEST QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -65,7 +69,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D MANUFACTURED_SOURCE SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    MANUFACTURED_SOURCE
+                                    QUICK
+                                    UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -102,7 +111,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    CONVECTIVE_JACOBIAN
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -142,7 +156,11 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST ${dim}D QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    MODERATE
+                                    UNIT_TEST)
 
     unset(TEST_TARGET)
 

--- a/tests/unit_tests/flow_variable_tests/CMakeLists.txt
+++ b/tests/unit_tests/flow_variable_tests/CMakeLists.txt
@@ -34,9 +34,17 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE SERIAL QUICK UNIT_TESTS)
+        set_tests_labels(${TEST_TARGET} FLOW_VARIABLE
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TESTS)
     else()
-        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE PARALLEL QUICK UNIT_TESTS)
+        set_tests_labels(${TEST_TARGET} FLOW_VARIABLE
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TESTS)
     endif()
     unset(TEST_TARGET)
     unset(OperatorsLib)
@@ -79,9 +87,17 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE SERIAL QUICK UNIT_TESTS)
+        set_tests_labels(${TEST_TARGET} FLOW_VARIABLE
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TESTS)
     else()
-        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE PARALLEL QUICK UNIT_TESTS)
+        set_tests_labels(${TEST_TARGET} FLOW_VARIABLE
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TESTS)
     endif()
     unset(TEST_TARGET)
     unset(OperatorsLib)

--- a/tests/unit_tests/flow_variable_tests/CMakeLists.txt
+++ b/tests/unit_tests/flow_variable_tests/CMakeLists.txt
@@ -33,7 +33,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE SERIAL QUICK UNIT_TESTS)
+    else()
+        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE PARALLEL QUICK UNIT_TESTS)
+    endif()
     unset(TEST_TARGET)
     unset(OperatorsLib)
 
@@ -74,7 +78,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE SERIAL QUICK UNIT_TESTS)
+    else()
+        set_tests_labels(${TEST_TARGET} ${dim}D FLOW_VARIABLE PARALLEL QUICK UNIT_TESTS)
+    endif()
     unset(TEST_TARGET)
     unset(OperatorsLib)
 

--- a/tests/unit_tests/functional_derivatives/CMakeLists.txt
+++ b/tests/unit_tests/functional_derivatives/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D FUNCTIONAL_DERIVATIVES QUICK UNIT_TEST)
     unset(dim)
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -87,7 +87,7 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D FUNCTIONAL_DERIVATIVES QUICK UNIT_TEST)
     unset(dim)
     unset(TEST_TARGET)
     unset(PhysicsLib)

--- a/tests/unit_tests/functional_derivatives/CMakeLists.txt
+++ b/tests/unit_tests/functional_derivatives/CMakeLists.txt
@@ -37,7 +37,11 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D FUNCTIONAL_DERIVATIVES QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} FUNCTIONAL_DERIVATIVES
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(dim)
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -87,7 +91,11 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D FUNCTIONAL_DERIVATIVES QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} FUNCTIONAL_DERIVATIVES
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(dim)
     unset(TEST_TARGET)
     unset(PhysicsLib)

--- a/tests/unit_tests/grid/CMakeLists.txt
+++ b/tests/unit_tests/grid/CMakeLists.txt
@@ -37,7 +37,11 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} GRID
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
 
 endforeach()
@@ -72,7 +76,11 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} GRID
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(HighOrderGridLib)
 
@@ -111,7 +119,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                            ${dim}D
+                                            PARALLEL
+                                            QUICK
+                                            UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -148,7 +160,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                            ${dim}D
+                                            PARALLEL
+                                            QUICK
+                                            UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -185,7 +201,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                            ${dim}D
+                                            PARALLEL
+                                            QUICK
+                                            UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -234,9 +254,23 @@ foreach(dim RANGE 1 3)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                                    ${dim}D
+                                                    SERIAL
+                                                    QUICK
+                                                    UNIT_TEST)
+    elseif (dim EQUAL 2)
+        set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                                    ${dim}D
+                                                    PARALLEL
+                                                    QUICK
+                                                    UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET}_${LENGTH}   GRID
+                                                    ${dim}D
+                                                    PARALLEL
+                                                    LONG
+                                                    UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(HighOrderGridLib)
@@ -272,7 +306,11 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET} ${dim}D GRID PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET} GRID
+                                ${dim}D
+                                PARALLEL
+                                QUICK
+                                UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 

--- a/tests/unit_tests/grid/CMakeLists.txt
+++ b/tests/unit_tests/grid/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
     unset(TEST_TARGET)
 
 endforeach()
@@ -72,7 +72,7 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
     unset(TEST_TARGET)
     unset(HighOrderGridLib)
 
@@ -111,6 +111,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -147,6 +148,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -183,6 +185,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID QUICK PARALLEL UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 
@@ -230,7 +233,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET}_${LENGTH} ${dim}D GRID PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(HighOrderGridLib)
 
@@ -265,7 +272,7 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(${TEST_TARGET} ${dim}D GRID PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 unset(HighOrderGridLib)
 

--- a/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
+++ b/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
@@ -55,6 +55,12 @@ foreach(dim RANGE 2 3)
       COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/${dim}D_GMSH_READER --input=${dim}D_square.msh
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${dim}D_GMSH_READER_SQUARE GRID
+                                                ${dim}D
+                                                PARALLEL
+                                                GMSH
+                                                QUICK
+                                                UNIT_TEST)
 endforeach()
 
 set (filename "airfoil.msh")
@@ -72,6 +78,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/2D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_GMSH_READER_NACA0012    GRID
+                                            2D
+                                            PARALLEL
+                                            GMSH
+                                            QUICK
+                                            UNIT_TEST)
 
 set (filename "naca0012_hopw_ref2.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -88,6 +100,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/2D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(2D_GMSH_READER_NACA0012_HOPW   GRID
+                                                2D
+                                                PARALLEL
+                                                GMSH
+                                                QUICK
+                                                UNIT_TEST)
 
 set (filename "3D_CUBE_2ndOrder.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -104,6 +122,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_3D_CUBE_2ndOrder   GRID
+                                                3D
+                                                PARALLEL
+                                                GMSH
+                                                QUICK
+                                                UNIT_TEST)
 
 set (filename "3d_gaussian_bump.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -120,7 +144,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-
+set_tests_labels(3D_GMSH_READER_3D_GAUSSIAN_BUMP    GRID
+                                                    3D
+                                                    PARALLEL
+                                                    GMSH
+                                                    QUICK
+                                                    UNIT_TEST)
 set (filename "3d_cube_periodic.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
   message(SEND_ERROR
@@ -136,6 +165,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_3D_CUBE_PERIODIC    GRID
+                                                    3D
+                                                    PARALLEL
+                                                    GMSH
+                                                    QUICK
+                                                    UNIT_TEST)
 
 set (filename "SD7003_1_cell_spanwise.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -152,6 +187,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_SD7003_01_CELL_SPANWISE GRID
+                                                        3D
+                                                        PARALLEL
+                                                        GMSH
+                                                        QUICK
+                                                        UNIT_TEST)
 
 set (filename "SD7003_4_cell_spanwise.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -168,6 +209,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_SD7003_04_CELL_SPANWISE GRID
+                                                        3D
+                                                        PARALLEL
+                                                        GMSH
+                                                        QUICK
+                                                        UNIT_TEST)
 
 set (filename "SD7003_12_cell_spanwise.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -184,6 +231,12 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_SD7003_12_CELL_SPANWISE GRID
+                                                        3D
+                                                        PARALLEL
+                                                        GMSH
+                                                        QUICK
+                                                        UNIT_TEST)
 
 set (filename "channel_structured.msh")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
@@ -200,3 +253,9 @@ add_test(
   COMMAND mpirun -n ${MPIMAX} ${CMAKE_CURRENT_BINARY_DIR}/3D_GMSH_READER --input=${filename}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(3D_GMSH_READER_CHANNEL_STRUCTURED  GRID
+                                                    3D
+                                                    PARALLEL
+                                                    GMSH
+                                                    QUICK
+                                                    UNIT_TEST)

--- a/tests/unit_tests/linear_solver/CMakeLists.txt
+++ b/tests/unit_tests/linear_solver/CMakeLists.txt
@@ -24,51 +24,87 @@ endif()
 
 ADD_TEST(NAME NNLS_known_tests
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> known)
-set_tests_labels(NNLS_known_tests NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_known_tests   NNLS
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
 ADD_TEST(NAME NNLS_matlab_test
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> matlab)
-set_tests_labels(NNLS_matlab_test NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_matlab_test   NNLS
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
 ADD_TEST(NAME NNLS_no_cols_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> noCols)
-set_tests_labels(NNLS_no_cols_matrix NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_no_cols_matrix    NNLS
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
 
 ADD_TEST(NAME NNLS_empty_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> empty)
-set_tests_labels(NNLS_empty_matrix NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_empty_matrix  NNLS
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
 ADD_TEST(NAME NNLS_random_problem
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> random)
-set_tests_labels(NNLS_random_problem NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_random_problem    NNLS
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
 
 ADD_TEST(NAME NNLS_zero_RHS
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> zeroRHS)
-set_tests_labels(NNLS_zero_RHS NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_zero_RHS  NNLS
+                                SERIAL
+                                QUICK
+                                UNIT_TEST)
 
 ADD_TEST(NAME NNLS_dependent_columns
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> depCols)
-set_tests_labels(NNLS_dependent_columns NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_dependent_columns NNLS
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
 
 ADD_TEST(NAME NNLS_wide_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> wide)
-set_tests_labels(NNLS_wide_matrix NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_wide_matrix   NNLS
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
 ADD_TEST(NAME NNLS_zero_iter_w_sol
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> zeroIter)
-set_tests_labels(NNLS_zero_iter_w_sol NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_zero_iter_w_sol   NNLS
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
 
 ADD_TEST(NAME NNLS_n_iter
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> nIter)
-set_tests_labels(NNLS_n_iter NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_n_iter    NNLS
+                                SERIAL
+                                QUICK
+                                UNIT_TEST)
 
 ADD_TEST(NAME NNLS_max_iter
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> maxIter)
-set_tests_labels(NNLS_max_iter NNLS QUICK SERIAL UNIT_TEST)
+set_tests_labels(NNLS_max_iter  NNLS
+                                SERIAL
+                                QUICK
+                                UNIT_TEST)
 
 ADD_TEST(NAME NNLS_multi_core
 COMMAND mpirun -n ${MPIMAX} $<TARGET_FILE:Tests.exe> multiCore)
-set_tests_labels(NNLS_multi_core NNLS QUICK PARALLEL UNIT_TEST)
+set_tests_labels(NNLS_multi_core    NNLS
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
 
 #set(TEST_SRC
 #	NNLS_tests.cpp)

--- a/tests/unit_tests/linear_solver/CMakeLists.txt
+++ b/tests/unit_tests/linear_solver/CMakeLists.txt
@@ -24,42 +24,52 @@ endif()
 
 ADD_TEST(NAME NNLS_known_tests
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> known)
+set_tests_labels(NNLS_known_tests NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_matlab_test
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> matlab)
+set_tests_labels(NNLS_matlab_test NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_no_cols_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> noCols)
+set_tests_labels(NNLS_no_cols_matrix NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_empty_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> empty)
+set_tests_labels(NNLS_empty_matrix NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_random_problem
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> random)
+set_tests_labels(NNLS_random_problem NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_zero_RHS
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> zeroRHS)
+set_tests_labels(NNLS_zero_RHS NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_dependent_columns
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> depCols)
+set_tests_labels(NNLS_dependent_columns NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_wide_matrix
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> wide)
+set_tests_labels(NNLS_wide_matrix NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_zero_iter_w_sol
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> zeroIter)
+set_tests_labels(NNLS_zero_iter_w_sol NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_n_iter
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> nIter)
+set_tests_labels(NNLS_n_iter NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_max_iter
 COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> maxIter)
+set_tests_labels(NNLS_max_iter NNLS QUICK SERIAL UNIT_TEST)
 
 ADD_TEST(NAME NNLS_multi_core
 COMMAND mpirun -n ${MPIMAX} $<TARGET_FILE:Tests.exe> multiCore)
-SET_TESTS_PROPERTIES(NNLS_multi_core PROPERTIES LABELS NNLS
-        LABELS QUICK
-        LABELS UNIT_TEST)
+set_tests_labels(NNLS_multi_core NNLS QUICK PARALLEL UNIT_TEST)
+
 #set(TEST_SRC
 #	NNLS_tests.cpp)
 #

--- a/tests/unit_tests/linear_solver/CMakeLists.txt
+++ b/tests/unit_tests/linear_solver/CMakeLists.txt
@@ -57,7 +57,9 @@ COMMAND ${MPIGO} $<TARGET_FILE:Tests.exe> maxIter)
 
 ADD_TEST(NAME NNLS_multi_core
 COMMAND mpirun -n ${MPIMAX} $<TARGET_FILE:Tests.exe> multiCore)
-
+SET_TESTS_PROPERTIES(NNLS_multi_core PROPERTIES LABELS NNLS
+        LABELS QUICK
+        LABELS UNIT_TEST)
 #set(TEST_SRC
 #	NNLS_tests.cpp)
 #

--- a/tests/unit_tests/msh_output/CMakeLists.txt
+++ b/tests/unit_tests/msh_output/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D MESH_OUT PARALLEL UNIT_TESTS)
     unset(TEST_TARGET)
     unset(GridRefinementLib)
 endforeach()

--- a/tests/unit_tests/msh_output/CMakeLists.txt
+++ b/tests/unit_tests/msh_output/CMakeLists.txt
@@ -25,7 +25,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D MESH_OUT PARALLEL UNIT_TESTS)
+    set_tests_labels(${TEST_TARGET} MESH_OUTPUT
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TESTS)
     unset(TEST_TARGET)
     unset(GridRefinementLib)
 endforeach()

--- a/tests/unit_tests/navier_stokes_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/navier_stokes_unit_test/CMakeLists.txt
@@ -28,7 +28,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D NAVIER_STOKES_UNIT_TEST QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -65,7 +69,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D MANUFACTURED_SOURCE NAVIER_STOKES_UNIT_TEST QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    MANUFACTURED_SOURCE
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -101,7 +110,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    CONVECTIVE_JACOBIAN
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -137,7 +151,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    CONVECTIVE_JACOBIAN
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -173,7 +192,12 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D VISCOSITY QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    VISCOSITY
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -209,7 +233,13 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D RANS MANUFACTURED_SOURCE QUICK SERIAL UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    RANS
+                                    MANUFACTURED_SOURCE
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 

--- a/tests/unit_tests/navier_stokes_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/navier_stokes_unit_test/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${TEST_TARGET} ${dim}D NAVIER_STOKES_UNIT_TEST QUICK SERIAL UNIT_TEST)
 
     unset(TEST_TARGET)
     unset(PhysicsLib)
@@ -64,7 +65,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D MANUFACTURED_SOURCE NAVIER_STOKES_UNIT_TEST QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -100,7 +101,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -136,7 +137,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D CONVECTIVE_JACOBIAN QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -172,7 +173,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D VISCOSITY QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 
@@ -208,7 +209,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} NAVIER_STOKES_UNIT_TEST ${dim}D RANS MANUFACTURED_SOURCE QUICK SERIAL UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
 

--- a/tests/unit_tests/numerical_flux/CMakeLists.txt
+++ b/tests/unit_tests/numerical_flux/CMakeLists.txt
@@ -35,6 +35,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    set_tests_labels(${TEST_TARGET} NUMERICAL_FLUX SERIAL QUICK UNIT_TEST)
 
     unset(dim)
     unset(TEST_TARGET)

--- a/tests/unit_tests/numerical_flux/CMakeLists.txt
+++ b/tests/unit_tests/numerical_flux/CMakeLists.txt
@@ -35,7 +35,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} NUMERICAL_FLUX SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} NUMERICAL_FLUX
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
 
     unset(dim)
     unset(TEST_TARGET)

--- a/tests/unit_tests/ode_solver_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/ode_solver_unit_test/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(dim RANGE 1 1)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D EXPLICIT_SOLVER SERIAL UNIT_TESTS)
     unset(dim)
     unset(TEST_TARGET)
 

--- a/tests/unit_tests/ode_solver_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/ode_solver_unit_test/CMakeLists.txt
@@ -30,7 +30,11 @@ foreach(dim RANGE 1 1)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D EXPLICIT_SOLVER SERIAL UNIT_TESTS)
+    set_tests_labels(${TEST_TARGET} ODE_SOLVER
+                                    ${dim}D
+                                    SERIAL
+                                    MODERATE
+                                    UNIT_TESTS)
     unset(dim)
     unset(TEST_TARGET)
 

--- a/tests/unit_tests/operator_tests/CMakeLists.txt
+++ b/tests/unit_tests/operator_tests/CMakeLists.txt
@@ -28,7 +28,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -63,7 +67,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -97,7 +105,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -131,7 +143,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -166,7 +182,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -201,7 +221,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -237,7 +261,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -272,7 +300,20 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    if (dim EQUAL 2)
+        set_tests_labels(${TEST_TARGET} OPERATOR
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} OPERATOR
+                                        ${dim}D
+                                        PARALLEL
+                                        MODERATE
+                                        UNIT_TEST)
+    endif()
+
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -307,7 +348,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -341,7 +386,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -495,7 +544,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -571,7 +624,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -609,7 +666,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -647,7 +708,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -684,7 +749,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -722,7 +791,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -760,7 +833,11 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -797,7 +874,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
     unset(GridsLib)
@@ -834,7 +915,11 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} OPERATOR
+                                    ${dim}D
+                                    PARALLEL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
     unset(GridsLib)

--- a/tests/unit_tests/operator_tests/CMakeLists.txt
+++ b/tests/unit_tests/operator_tests/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -63,7 +63,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -97,7 +97,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -131,7 +131,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -166,7 +166,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -201,7 +201,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -237,7 +237,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -272,7 +272,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -307,7 +307,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -341,7 +341,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -495,7 +495,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
 endforeach()
@@ -571,7 +571,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -609,7 +609,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -647,7 +647,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -684,7 +684,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -722,7 +722,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -760,7 +760,7 @@ foreach(dim RANGE 1 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     # unset(ParametersLib)
     unset(OperatorsLib)
@@ -797,7 +797,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
     unset(GridsLib)
@@ -834,7 +834,7 @@ foreach(dim RANGE 2 3)
       NAME ${TEST_TARGET}
       COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR})
-
+    set_tests_labels(${TEST_TARGET} ${dim}D OPERATOR PARALLEL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(OperatorsLib)
     unset(GridsLib)

--- a/tests/unit_tests/optimization/CMakeLists.txt
+++ b/tests/unit_tests/optimization/CMakeLists.txt
@@ -20,7 +20,10 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} OPTIMIZATION SERIAL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                SERIAL
+                                                QUICK
+                                                UNIT_TEST)
 
 if(NOT NMPI EQUAL ${MPIMAX})
   set(NMPI ${MPIMAX})
@@ -29,7 +32,10 @@ if(NOT NMPI EQUAL ${MPIMAX})
     COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
     WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
   )
-  set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+  set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}  OPTIMIZATION
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 endif()
 
 unset(TEST_TARGET)
@@ -69,7 +75,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                ${dim}D
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 unset(TEST_TARGET)
 
 set(TEST_SRC
@@ -108,7 +118,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                ${dim}D
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 unset(TEST_TARGET)
 
 ##################################################################################################################################
@@ -144,7 +158,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                ${dim}D
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################
 
@@ -182,7 +200,11 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                ${dim}D
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################
 
@@ -219,6 +241,10 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI}    OPTIMIZATION
+                                                ${dim}D
+                                                PARALLEL
+                                                QUICK
+                                                UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################

--- a/tests/unit_tests/optimization/CMakeLists.txt
+++ b/tests/unit_tests/optimization/CMakeLists.txt
@@ -20,6 +20,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} OPTIMIZATION SERIAL QUICK UNIT_TEST)
 
 if(NOT NMPI EQUAL ${MPIMAX})
   set(NMPI ${MPIMAX})
@@ -28,6 +29,7 @@ if(NOT NMPI EQUAL ${MPIMAX})
     COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
     WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
   )
+  set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 endif()
 
 unset(TEST_TARGET)
@@ -67,6 +69,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 
 set(TEST_SRC
@@ -105,6 +108,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 
 ##################################################################################################################################
@@ -140,6 +144,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################
 
@@ -177,6 +182,7 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################
 
@@ -213,5 +219,6 @@ add_test(
   COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
+set_tests_labels(${TEST_TARGET}_nmpi=${NMPI} ${dim}D OPTIMIZATION PARALLEL QUICK UNIT_TEST)
 unset(TEST_TARGET)
 ##################################################################################################################################

--- a/tests/unit_tests/regression/CMakeLists.txt
+++ b/tests/unit_tests/regression/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D REGRESSION SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
     unset(NumericalFluxLib)

--- a/tests/unit_tests/regression/CMakeLists.txt
+++ b/tests/unit_tests/regression/CMakeLists.txt
@@ -32,7 +32,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D REGRESSION SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET} REGRESSION
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
     unset(TEST_TARGET)
     unset(PhysicsLib)
     unset(NumericalFluxLib)

--- a/tests/unit_tests/sensitivities/CMakeLists.txt
+++ b/tests/unit_tests/sensitivities/CMakeLists.txt
@@ -43,6 +43,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
 
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -87,7 +92,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -138,7 +147,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
     unset(DiscontinuousGalerkinLib)
@@ -191,7 +204,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
     unset(DiscontinuousGalerkinLib)
@@ -244,7 +261,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -287,7 +308,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -333,7 +358,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
     unset(GridsLib)
@@ -378,7 +407,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -424,7 +457,11 @@ foreach(dim RANGE 1 3)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -470,7 +507,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 
@@ -513,7 +554,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
     unset(HighOrderGridLib)
@@ -534,7 +579,7 @@ foreach(dim RANGE 2 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
     unset(TEST_TARGET)
 
 endforeach()
@@ -579,7 +624,11 @@ foreach(dim RANGE 1 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-
+    if (dim EQUAL 1)
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    else ()
+        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+    endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
 

--- a/tests/unit_tests/sensitivities/CMakeLists.txt
+++ b/tests/unit_tests/sensitivities/CMakeLists.txt
@@ -44,9 +44,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        MODERATE
+                                        UNIT_TEST)
     endif()
 
     unset(TEST_TARGET)
@@ -93,9 +101,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -148,9 +164,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        LONG
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -205,9 +229,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        LONG
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -262,9 +294,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        LONG
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -309,9 +349,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -359,9 +407,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -408,9 +464,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -458,9 +522,17 @@ foreach(dim RANGE 1 3)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -508,9 +580,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -555,9 +635,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)
@@ -579,7 +667,11 @@ foreach(dim RANGE 2 2)
       COMMAND mpirun -n ${NMPI} ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
-    set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+    set_tests_labels(${TEST_TARGET}_serial  SENSITIVITIES
+                                            ${dim}D
+                                            SERIAL
+                                            QUICK
+                                            UNIT_TEST)
     unset(TEST_TARGET)
 
 endforeach()
@@ -625,9 +717,17 @@ foreach(dim RANGE 1 2)
       WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
     )
     if (dim EQUAL 1)
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES SERIAL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        SERIAL
+                                        QUICK
+                                        UNIT_TEST)
     else ()
-        set_tests_labels(${TEST_TARGET} ${dim}D SENSITIVITIES PARALLEL QUICK UNIT_TEST)
+        set_tests_labels(${TEST_TARGET} SENSITIVITIES
+                                        ${dim}D
+                                        PARALLEL
+                                        QUICK
+                                        UNIT_TEST)
     endif()
     unset(TEST_TARGET)
     unset(ParametersLib)


### PR DESCRIPTION
This PR adds labels to all current CTests and sets a standard for the labels to be included in CTests in the future.
## How to add labels
To add labels use the custom ctest function, defined in ./tests/CMakeLists.txt,  `set_tests_labels`. This function takes one input and as many arguments as needed. The one input is the test name and the arguments are the labels wanted. See below for an example use.
```
ADD_TEST(NAME NNLS_multi_core
COMMAND mpirun -n ${MPIMAX} $<TARGET_FILE:Tests.exe> multiCore)
set_tests_labels(NNLS_multi_core    NNLS
                                    PARALLEL
                                    QUICK
                                    UNIT_TEST)
```
## Current Labels
Test labels should be added for the following categories (USE ALL CAPS)
- Test Group
   - NNLS, TGV_SCALING, ETC
- Dimension
   - 1D, 2D, 3D
- Parallel vs Serial
   - PARALLEL, SERIAL
- PDE Type
   - EULER, NAVIER-STOKES, etc
- ODE Solver Type
   - RUNGE-KUTTA, IMPLICIT, etc
- DG Type
   - STRONG, STRONG-SPLIT, WEAK
- Quadrature Type
   - COLLOCATED, UNCOLLOCATED
- OTHER (if needed)
	- MEMORY_INTENSIVE, MANUFACTURED_SOLUTION, EXPECTED_FAILURE, CONVERGENCE etc
- Speed of Test
	- QUICK (<~10s), MODERATE(<~180s), LONG(>~180s)
- Type of Test
	- UNIT_TEST, INTEGRATION_TEST, FLOW_SIMULATION