### PR TITLE
Assemble residual on only a  subset of element

### DIFF
--- a/src/dg/dg_base.cpp
+++ b/src/dg/dg_base.cpp
@@ -1359,6 +1359,24 @@ bool DGBase<dim,real,MeshType>::do_assemble_in_this_cell(const unsigned int cell
     }
 }
 
+
+template <int dim, typename real, typename MeshType>
+void DGBase<dim,real,MeshType>::set_list_of_cell_group_IDs(const dealii::LinearAlgebra::distributed::Vector<int> locations, const int group_ID) {
+
+    // check sizes - not sure if necessary.
+    // bool is_compatible = locations.partitioners_are_compatible(this->list_of_cell_group_IDs);
+
+    // Using only deal.ii vector operations herein to take advantage of their optimizations
+    // Set the cell_group_ID at the given location to zero without changing existing values
+    dealii::LinearAlgebra::distributed::Vector<int> locations_copy((locations));
+    locations_copy.add(-1);
+    locations_copy*=-1;
+    this->list_of_cell_group_IDs.scale(locations_copy);
+    // Set the cell_group_ID at the given location to the group_ID
+    this->list_of_cell_group_IDs.add(group_ID,locations);
+
+}
+
 template <int dim, typename real, typename MeshType>
 double DGBase<dim,real,MeshType>::get_residual_linfnorm () const
 {

--- a/src/dg/dg_base.hpp
+++ b/src/dg/dg_base.hpp
@@ -606,6 +606,14 @@ protected:
      *  or partitioned Runge-Kutta.
      */
     dealii::LinearAlgebra::distributed::Vector<int> list_of_cell_group_IDs;
+public:
+
+    ///Setter for list_of_cell_group_IDs
+    /** Useage: pass a vector of the same size as the list_of_cell_group_IDs
+     *  where 1 indicates that that cell should be assigned the indicated
+     *  group_ID
+     */
+    void set_list_of_cell_group_IDs(const dealii::LinearAlgebra::distributed::Vector<int> locations, const int group_ID);
 
 public:
 

--- a/src/dg/dg_base.hpp
+++ b/src/dg/dg_base.hpp
@@ -559,9 +559,11 @@ public:
      * 4. Neighbor is coarser. Therefore, the current cell is the finer one.
      * Do nothing since this cell will be taken care of by scenario 2.
      *
+     * The residual is only assembled for the indicated cell_group_ID.
+     *
      */
     //void assemble_residual_dRdW ();
-    void assemble_residual (const bool compute_dRdW=false, const bool compute_dRdX=false, const bool compute_d2R=false, const double CFL_mass = 0.0);
+    void assemble_residual (const bool compute_dRdW=false, const bool compute_dRdX=false, const bool compute_d2R=false, const double CFL_mass = 0.0, const int cell_group_ID = 0);
 
     /// Used in assemble_residual().
     /** IMPORTANT: This does not fully compute the cell residual since it might not
@@ -589,6 +591,23 @@ public:
         const bool                                                         compute_auxiliary_right_hand_side,//flag on whether computing the Auxiliary variable's equations' residuals
         dealii::LinearAlgebra::distributed::Vector<double>                 &rhs,
         std::array<dealii::LinearAlgebra::distributed::Vector<double>,dim> &rhs_aux);
+
+    /// Function to determine whether the residual should be assembled in a given cell
+    /** Returns true if the current cell belongs to cell_group_ID
+     *  If the cell is not in that group, return false.
+     */
+    bool do_assemble_in_this_cell(const unsigned int cell_index, const int cell_group_ID) const;
+
+protected:
+    /// List of the group ID of each cell.
+    /** This is used to determine whether the residual will be evaluated.
+     *  By default, this is a list of zeroes, indicating that all cells are evaluated together.
+     *  The group IDs are intended to be used with hyperreduced order models
+     *  or partitioned Runge-Kutta.
+     */
+    dealii::LinearAlgebra::distributed::Vector<int> list_of_cell_group_IDs;
+
+public:
 
     /// Finite Element Collection for p-finite-element to represent the solution
     /** This is a collection of FESystems */
@@ -880,7 +899,7 @@ public:
     void allocate_auxiliary_equation ();
 
     /// Asembles the auxiliary equations' residuals and solves.
-    virtual void assemble_auxiliary_residual () = 0;
+    virtual void assemble_auxiliary_residual (const unsigned int cell_group_ID=0) = 0;
 
     /// Allocate the dual vector for optimization.
     /** Currently only used in weak form.

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -395,7 +395,7 @@ void DGStrong<dim,nstate,real,MeshType>::assemble_subface_term_and_build_operato
  *******************************************************************/
 
 template <int dim, int nstate, typename real, typename MeshType>
-void DGStrong<dim,nstate,real,MeshType>::assemble_auxiliary_residual()
+void DGStrong<dim,nstate,real,MeshType>::assemble_auxiliary_residual(const unsigned int cell_group_ID)
 {
     using PDE_enum = Parameters::AllParameters::PartialDifferentialEquation;
     using ODE_enum = Parameters::ODESolverParam::ODESolverEnum;
@@ -443,7 +443,7 @@ void DGStrong<dim,nstate,real,MeshType>::assemble_auxiliary_residual()
         //loop over cells solving for auxiliary rhs
         auto metric_cell = this->high_order_grid->dof_handler_grid.begin_active();
         for (auto soln_cell = this->dof_handler.begin_active(); soln_cell != this->dof_handler.end(); ++soln_cell, ++metric_cell) {
-            if (!soln_cell->is_locally_owned()) continue;
+            if (!soln_cell->is_locally_owned() && !this->do_assemble_in_this_cell(soln_cell->active_fe_index(), cell_group_ID)) continue;
 
             this->assemble_cell_residual (
                 soln_cell,

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -32,8 +32,9 @@ public:
     /** For information regarding auxiliary vs. primary quations, see 
      *  Quaegebeur, Nadarajah, Navah and Zwanenburg 2019: Stability of Energy Stable Flux 
      *                Reconstruction for the Diffusion Problem Using Compact Numerical Fluxes
+     *  The aux residual is only assembled for the indicated cell_group_ID.
      */
-    void assemble_auxiliary_residual ();
+    void assemble_auxiliary_residual (const unsigned int cell_group_ID=0);
 
     /// Allocate the dual vector for optimization.
     void allocate_dual_vector ();

--- a/src/dg/weak_dg.cpp
+++ b/src/dg/weak_dg.cpp
@@ -3914,7 +3914,7 @@ void DGWeak<dim,nstate,real,MeshType>::assemble_subface_term_and_build_operators
 }
 
 template <int dim, int nstate, typename real, typename MeshType>
-void DGWeak<dim,nstate,real,MeshType>::assemble_auxiliary_residual ()
+void DGWeak<dim,nstate,real,MeshType>::assemble_auxiliary_residual (const unsigned int /*cell_group_ID*/)
 {
     //Do Nothing.
 }

--- a/src/dg/weak_dg.hpp
+++ b/src/dg/weak_dg.hpp
@@ -158,7 +158,7 @@ private:
         const bool compute_dRdW, const bool compute_dRdX, const bool compute_d2R);
 
     /// Assembles the auxiliary equations' residuals and solves for the auxiliary variables.
-    void assemble_auxiliary_residual ();
+    void assemble_auxiliary_residual (const unsigned int cell_group_ID=0);
 
     /// Allocate the dual vector for optimization.
     void allocate_dual_vector ();


### PR DESCRIPTION
This PR modifies DG such that the residual can be assembled on only a subset of elements.

The vector `list_of_cell_group_IDs` designates a `cell_group_ID` to each cell in the domain. `cell_group_ID` is passed to the `assemble_residual` function, and `assemble_cell_residual` is only called in cells with that ID. By default, the list is initialized to a vector of zeroes, such that the residual is assembled everywhere.