### PR TITLE
Addressing Issue 223

### DIFF
--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -45,7 +45,7 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     std::ofstream myfile (all_parameters_new.energy_file + ".gpl"  , std::ios::trunc);
     const unsigned int poly_degree_start= all_parameters->flow_solver_param.poly_degree;
 
-    const unsigned int poly_degree_end = 16;
+    const unsigned int poly_degree_end = 13;
     std::array<double,poly_degree_end> time_to_run;
     std::array<double,poly_degree_end> time_to_run_mpi;
 
@@ -129,6 +129,17 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
         return 1;
     }
 
+    /*
+     *  The following code tests an allocation of a high-P grid.
+     *  However, the success of the test is highly dependant on 
+     *  the system on which it is running. To avoid testfails
+     *  from running out of memory, this part of the test has
+     *  been commented.
+     *
+     *  For curvilinear grids, the test was known to pass on Alex
+     *  Cicchino's desktop, but has rarely passed on other systems,
+     *  including compute clusters.
+
     //check that it can run up to p=30 for Cartesian or p=20 for curvilinear without running out of memory.
     const unsigned int poly_degree = (all_parameters->use_curvilinear_grid) ? 20 : 30;
     const unsigned int grid_degree = (all_parameters->use_curvilinear_grid) ? poly_degree : 1;
@@ -168,9 +179,9 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
             dg->global_inverse_mass_matrix.vmult(solution_update, dg->right_hand_side);
         }
     }
+    */
+
     //if it reaches here, then there is no memory issue.
-
-
     return 0;
 }
 

--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -152,8 +152,6 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     // For curvilinear cases, check allocation in high order grid.
     // Create DG
     std::shared_ptr < PHiLiP::DGBase<dim, double> > dg = PHiLiP::DGFactory<dim,double>::create_discontinuous_galerkin(&all_parameters_new, poly_degree, poly_degree, grid_degree, grid);
-    // Allocate small amount of memory that can be deleted to avoid crashing other programs or getting OOM errors
-    char* _emergencyMemory = new char[16384];
     try{
         dg->allocate_system (false,false,false);
          
@@ -180,7 +178,6 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
         }
     }
     catch(std::bad_alloc &e){
-        delete[] _emergencyMemory;
         std::cout << "ending with bad_alloc (ran out of memory)" << std::endl;   
         std::cout << "If the test fails here, then there is unnecessary memory being allocated." << std::endl;
         return 1;

--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -152,6 +152,8 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     // For curvilinear cases, check allocation in high order grid.
     // Create DG
     std::shared_ptr < PHiLiP::DGBase<dim, double> > dg = PHiLiP::DGFactory<dim,double>::create_discontinuous_galerkin(&all_parameters_new, poly_degree, poly_degree, grid_degree, grid);
+    // Allocate small amount of memory that can be deleted to avoid crashing other programs or getting OOM errors
+    char* _emergencyMemory = new char[16384];
     try{
         dg->allocate_system (false,false,false);
          
@@ -178,6 +180,7 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
         }
     }
     catch(std::bad_alloc &e){
+        delete[] _emergencyMemory;
         std::cout << "ending with bad_alloc (ran out of memory)" << std::endl;   
         std::cout << "If the test fails here, then there is unnecessary memory being allocated." << std::endl;
         return 1;

--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -45,9 +45,12 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     std::ofstream myfile (all_parameters_new.energy_file + ".gpl"  , std::ios::trunc);
     const unsigned int poly_degree_start= all_parameters->flow_solver_param.poly_degree;
 
-    const unsigned int poly_degree_end = 13;
-    std::array<double,poly_degree_end> time_to_run;
-    std::array<double,poly_degree_end> time_to_run_mpi;
+    const unsigned int poly_degree_end = (all_parameters->use_curvilinear_grid) ? 16 : 13;
+    std::vector<double> time_to_run;
+    time_to_run.reserve(poly_degree_end);
+    //std::array<double,poly_degree_end> time_to_run_mpi;
+    std::vector<double> time_to_run_mpi;
+    time_to_run_mpi.reserve(poly_degree_end);
 
     //poly degree loop
     for(unsigned int poly_degree = poly_degree_start; poly_degree<poly_degree_end; poly_degree++){

--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -45,7 +45,7 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     std::ofstream myfile (all_parameters_new.energy_file + ".gpl"  , std::ios::trunc);
     const unsigned int poly_degree_start= all_parameters->flow_solver_param.poly_degree;
 
-    const unsigned int poly_degree_end = (all_parameters->use_curvilinear_grid) ? 13 : 16;
+    const unsigned int poly_degree_end = (all_parameters->use_curvilinear_grid) ? 11 : 16;
     pcout << "Max poly degree: " << poly_degree_end << std::endl;
     std::vector<double> time_to_run;
     time_to_run.reserve(poly_degree_end);
@@ -133,16 +133,7 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
         return 1;
     }
 
-    /*
-     *  The following code tests an allocation of a high-P grid.
-     *  However, the success of the test is highly dependant on 
-     *  the system on which it is running. To avoid testfails
-     *  from running out of memory, this part of the test has
-     *  been commented.
-     *
-     *  For curvilinear grids, the test was known to pass on Alex
-     *  Cicchino's desktop, but has rarely passed on other systems,
-     *  including compute clusters.
+
 
     //check that it can run up to p=30 for Cartesian or p=20 for curvilinear without running out of memory.
     const unsigned int poly_degree = (all_parameters->use_curvilinear_grid) ? 20 : 30;
@@ -158,33 +149,39 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     }
      
     pcout<<"Checking that it does not run out of memory for poly degree "<<poly_degree<<std::endl;
+    // For curvilinear cases, check allocation in high order grid.
     // Create DG
     std::shared_ptr < PHiLiP::DGBase<dim, double> > dg = PHiLiP::DGFactory<dim,double>::create_discontinuous_galerkin(&all_parameters_new, poly_degree, poly_degree, grid_degree, grid);
-    dg->allocate_system (false,false,false);
-     
-    std::shared_ptr< InitialConditionFunction<dim,nstate,double> > initial_condition_function = 
-                InitialConditionFactory<dim,nstate,double>::create_InitialConditionFunction(&all_parameters_new);
-    SetInitialCondition<dim,nstate,double>::set_initial_condition(initial_condition_function, dg, &all_parameters_new);
-     
-    std::shared_ptr<ODE::ODESolverBase<dim, double>> ode_solver = ODE::ODESolverFactory<dim, double>::create_ODESolver(dg);
-     
-    ode_solver->current_iteration = 0;
-    ode_solver->allocate_ode_system();
-    MPI_Barrier(MPI_COMM_WORLD);
-    pcout << "ODE solver successfully created. This verifies no memory jump from ODE Solver." << std::endl;
-    dealii::LinearAlgebra::distributed::Vector<double> solution_update;
-    solution_update.reinit(dg->locally_owned_dofs, dg->ghost_dofs, this->mpi_communicator);
+    try{
+        dg->allocate_system (false,false,false);
+         
+        std::shared_ptr< InitialConditionFunction<dim,nstate,double> > initial_condition_function = 
+                    InitialConditionFactory<dim,nstate,double>::create_InitialConditionFunction(&all_parameters_new);
+        SetInitialCondition<dim,nstate,double>::set_initial_condition(initial_condition_function, dg, &all_parameters_new);
+         
+        std::shared_ptr<ODE::ODESolverBase<dim, double>> ode_solver = ODE::ODESolverFactory<dim, double>::create_ODESolver(dg);
+         
+        ode_solver->current_iteration = 0;
+        ode_solver->allocate_ode_system();
+        MPI_Barrier(MPI_COMM_WORLD);
+        pcout << "ODE solver successfully created. This verifies no memory jump from ODE Solver." << std::endl;
+        dealii::LinearAlgebra::distributed::Vector<double> solution_update;
+        solution_update.reinit(dg->locally_owned_dofs, dg->ghost_dofs, this->mpi_communicator);
 
-    for(unsigned int i_step=0; i_step<10; i_step++){
-        dg->assemble_residual();
-        if(all_parameters->use_inverse_mass_on_the_fly){
-            dg->apply_inverse_global_mass_matrix(dg->right_hand_side, solution_update);
-        } else{
-            dg->global_inverse_mass_matrix.vmult(solution_update, dg->right_hand_side);
+        for(unsigned int i_step=0; i_step<10; i_step++){
+            dg->assemble_residual();
+            if(all_parameters->use_inverse_mass_on_the_fly){
+                dg->apply_inverse_global_mass_matrix(dg->right_hand_side, solution_update);
+            } else{
+                dg->global_inverse_mass_matrix.vmult(solution_update, dg->right_hand_side);
+            }
         }
     }
-    */
-
+    catch(std::bad_alloc &e){
+        std::cout << "ending with bad_alloc (ran out of memory)" << std::endl;   
+        std::cout << "If the test fails here, then there is unnecessary memory being allocated." << std::endl;
+        return 1;
+    }
     //if it reaches here, then there is no memory issue.
     return 0;
 }

--- a/src/testing/TGV_scaling.cpp
+++ b/src/testing/TGV_scaling.cpp
@@ -45,7 +45,8 @@ int EulerTaylorGreenScaling<dim, nstate>::run_test() const
     std::ofstream myfile (all_parameters_new.energy_file + ".gpl"  , std::ios::trunc);
     const unsigned int poly_degree_start= all_parameters->flow_solver_param.poly_degree;
 
-    const unsigned int poly_degree_end = (all_parameters->use_curvilinear_grid) ? 16 : 13;
+    const unsigned int poly_degree_end = (all_parameters->use_curvilinear_grid) ? 13 : 16;
+    pcout << "Max poly degree: " << poly_degree_end << std::endl;
     std::vector<double> time_to_run;
     time_to_run.reserve(poly_degree_end);
     //std::array<double,poly_degree_end> time_to_run_mpi;

--- a/tests/integration_tests_control_files/TGV_scaling/CMakeLists.txt
+++ b/tests/integration_tests_control_files/TGV_scaling/CMakeLists.txt
@@ -113,7 +113,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_split_form_curv.prm 3D_TGV_scaling_split_form_curv.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_SPLIT_FORM_CURV                                                                                                                                                                                    
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_split_form_curv.prm                                                                                                                                                                                                                                  
+ COMMAND bash -c 
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX}));
+ mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_split_form_curv.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_SPLIT_FORM_CURV    TGV_SCALING
@@ -132,7 +134,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_overint_curv.prm 3D_TGV_scaling_overint_curv.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_OVERINTEGRATION_CURV                                                                                                                                                                                    
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_overint_curv.prm                                                                                                                                                                                                                                  
+ COMMAND bash -c
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX})); 
+ mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_overint_curv.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_OVERINTEGRATION_CURV   TGV_SCALING
@@ -151,7 +155,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_cons_curv.prm 3D_TGV_scaling_cons_curv.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_CONSERVATIVE_CURV                                                                                                                                                                                    
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_cons_curv.prm                                                                                                                                                                                                                                  
+ COMMAND bash -c
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX}));
+  mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_cons_curv.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )                                                                                                                       
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_CONSERVATIVE_CURV  TGV_SCALING
@@ -171,7 +177,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_split_form_curv_cHU.prm 3D_TGV_scaling_split_form_curv_cHU.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_SPLIT_FORM_CHU_CURV                                                                                                                                                                                    
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_split_form_curv_cHU.prm                                                                                                                                                                                                                                  
+ COMMAND bash -c
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX}));
+  mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_split_form_curv_cHU.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_SPLIT_FORM_CHU_CURV    TGV_SCALING
@@ -191,7 +199,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_overint_curv_cHU.prm 3D_TGV_scaling_overint_curv_cHU.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_OVERINTEGRATION_CHU_CURV
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_overint_curv_cHU.prm                                                                                                                                                                                                                                  
+  COMMAND bash -c
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX}));
+ mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_overint_curv_cHU.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_OVERINTEGRATION_CHU_CURV   TGV_SCALING
@@ -211,7 +221,9 @@ set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(3D_TGV_scaling_cons_curv_cHU.prm 3D_TGV_scaling_cons_curv_cHU.prm COPYONLY)                                                                                                                                            
 add_test(                                                                                                                                                                                                                                 
  NAME MPI_3D_TAYLOR_GREEN_SCALING_CONSERVATIVE_CHU_CURV                                                                                                                                                                                    
- COMMAND mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_cons_curv_cHU.prm                                                                                                                                                                                                                                  
+  COMMAND bash -c
+ "ulimit -v $((2 * 1024 * 1024 * ${MPIMAX}));
+  mpirun -n ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3D_TGV_scaling_cons_curv_cHU.prm; "                                                                                                                                                                                                                                  
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}                                                                                                                                                                                                      
 )                                                                                                                       
 set_tests_labels(MPI_3D_TAYLOR_GREEN_SCALING_CONSERVATIVE_CHU_CURV  TGV_SCALING


### PR DESCRIPTION
Issue #223 has prevented the curvilinear scaling tests from passing on most machines. This PR lowers the maximum polynomial degree such that it will require a lower amount of memory. 

CMake has been changed to limit the maximum memory that this test can use, allowing it to fail without crashing computers or causing jobs to fail on OOM errors.