### PR TITLE
Fix issue 228

### DIFF
--- a/src/ode_solver/ode_solver_factory.cpp
+++ b/src/ode_solver/ode_solver_factory.cpp
@@ -330,7 +330,8 @@ std::shared_ptr<EmptyRRKBase<dim,real,MeshType>> ODESolverFactory<dim,real,MeshT
     // Type-cast to the appropriate RKTableau type
     std::shared_ptr<RKTableauButcherBase<dim,real,MeshType>> rk_tableau_butcher = std::dynamic_pointer_cast<RKTableauButcherBase<dim,real,MeshType>>(rk_tableau); 
 
-    if (ode_solver_type == ODEEnum::runge_kutta_solver && dg_input->all_parameters->flow_solver_param.do_calculate_numerical_entropy) {
+    if ( (ode_solver_type == ODEEnum::runge_kutta_solver && dg_input->all_parameters->flow_solver_param.do_calculate_numerical_entropy)
+            || ( !dg_input->all_parameters->ode_solver_param.use_relaxation_runge_kutta && dg_input->all_parameters->flow_solver_param.do_calculate_numerical_entropy )  ) {
             return std::make_shared<RKNumEntropy<dim,real,MeshType>>(rk_tableau_butcher);
     }
     else if (dg_input->all_parameters->ode_solver_param.use_relaxation_runge_kutta){


### PR DESCRIPTION
Adding an unforeseen condition to the RRK factory. Test `MPI_3D_EULER_NUMERICAL_ENTROPY_CONSERVATION_RRK_CPLUS` now passes.

Closes #288.