### PR TITLE
Renumber dofs warning

### DIFF
--- a/src/mesh/gmsh_reader.cpp
+++ b/src/mesh/gmsh_reader.cpp
@@ -1257,7 +1257,7 @@ read_gmsh(std::string filename,
 
     const int mpi_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
     dealii::ConditionalOStream pcout(std::cout, mpi_rank==0);
-    
+
 //    Assert(dim==2, dealii::ExcInternalError());
     std::ifstream infile;
 


### PR DESCRIPTION
Currently if a user tries to run a test using a GMSH mesh with do_renumber_dofs set to false, the test will fail with a segfault and not explanation.

This PR adds an error message in gmsh_reader.cpp and aborts the job before the segfault.

EDIT: After discussion, this PR has been modified to fix the segfault by passing in do_renumber_dofs when calling HighOrderGrid. The warning message has been removed.