### PR TITLE
Real Gas Entropy Variables

### DIFF
--- a/src/dg/dg_factory.cpp
+++ b/src/dg/dg_factory.cpp
@@ -109,6 +109,7 @@ DGFactory<dim,nspecies,real,MeshType>
         }
         else if (pde_type == PDE_enum::real_gas) {
         // nspecies > 1
+        // nspecies > 1
             return std::make_shared< DGStrong<dim,nspecies,dim+nspecies+1,real,MeshType> >(parameters_input, degree, max_degree_input, grid_degree_input, triangulation_input);
         } 
     }

--- a/src/dg/dg_factory.cpp
+++ b/src/dg/dg_factory.cpp
@@ -57,6 +57,7 @@ DGFactory<dim,nspecies,real,MeshType>
 #endif
         }
         else if (pde_type == PDE_enum::real_gas) {
+        // nspecies > 1
             return std::make_shared< DGWeak<dim,nspecies,dim+nspecies+1,real,MeshType> >(parameters_input, degree, max_degree_input, grid_degree_input, triangulation_input);
         } 
     } else {

--- a/src/dg/dg_factory.cpp
+++ b/src/dg/dg_factory.cpp
@@ -106,6 +106,9 @@ DGFactory<dim,nspecies,real,MeshType>
             }
 #endif
         }
+        else if (pde_type == PDE_enum::real_gas) {
+            return std::make_shared< DGStrong<dim,nspecies,dim+nspecies+1,real,MeshType> >(parameters_input, degree, max_degree_input, grid_degree_input, triangulation_input);
+        } 
     }
     std::cout << "Can't create DGBase in create_discontinuous_galerkin(). Invalid PDE type: " << pde_type << std::endl;
     return nullptr;

--- a/src/dg/dg_factory.cpp
+++ b/src/dg/dg_factory.cpp
@@ -107,6 +107,7 @@ DGFactory<dim,nspecies,real,MeshType>
 #endif
         }
         else if (pde_type == PDE_enum::real_gas) {
+        // nspecies > 1
             return std::make_shared< DGStrong<dim,nspecies,dim+nspecies+1,real,MeshType> >(parameters_input, degree, max_degree_input, grid_degree_input, triangulation_input);
         } 
     }

--- a/src/dg/dg_factory.cpp
+++ b/src/dg/dg_factory.cpp
@@ -109,7 +109,6 @@ DGFactory<dim,nspecies,real,MeshType>
         }
         else if (pde_type == PDE_enum::real_gas) {
         // nspecies > 1
-        // nspecies > 1
             return std::make_shared< DGStrong<dim,nspecies,dim+nspecies+1,real,MeshType> >(parameters_input, degree, max_degree_input, grid_degree_input, triangulation_input);
         } 
     }

--- a/src/physics/real_gas.cpp
+++ b/src/physics/real_gas.cpp
@@ -623,9 +623,10 @@ std::array<real,nspecies> RealGas<dim,nspecies,nstate,real>
     return e;
 }
 
+// Compute the Cv integral component of species entropy (ie. \int_{T_ref}^T c_v(\tau)/\tau d\tau) using NASA polynomials
 template <int dim, int nspecies, int nstate, typename real>
 std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
-::compute_species_entropy ( 
+::compute_species_entropy_cv_integral ( 
     const real temperature) const
 {
     real dimensional_temperature = compute_dimensional_temperature(temperature);
@@ -676,23 +677,38 @@ std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
         if (out_of_bounds_temp != -1.0)
             dimensional_temperature = out_of_bounds_temp;
         species_entropy[s] *= this->Rs[s];
+        species_entropy[s] -= this->Rs[s]*log(temperature);
     }
 
     return species_entropy;
 }
 
+// Compute species entropy by calculating integral and adding in density contribution (ie. R_k ln \rho_k)
+template <int dim, int nspecies, int nstate, typename real>
+std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
+::compute_species_entropy (
+    const std::array<real,nstate> &conservative_soln) const
+{
+    const real temperature = compute_temperature(conservative_soln);
+    const std::array<real,nspecies> species_densities = compute_species_densities(conservative_soln);
+
+    std::array<real,nspecies> species_entropy = compute_species_entropy_cv_integral(temperature);
+    for(int ispecies = 0; ispecies < nspecies; ispecies++) {
+        species_entropy[ispecies] -= this->Rs[ispecies]*log(temperature*species_densities[ispecies]*this->density_ref);
+    }
+
+    return species_entropy;
+}
+
+// Compute Gibbs' energy of species using species entropy and species Cp
 template <int dim, int nspecies, int nstate, typename real>
 std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
 ::compute_species_gibbs_energy (
     const std::array<real,nstate> &conservative_soln) const
 {
     const real temperature = compute_temperature(conservative_soln);
-    const std::array<real,nspecies> species_densities = compute_species_densities(conservative_soln);
 
-    std::array<real,nspecies> species_entropy = compute_species_entropy(temperature);
-    for(int ispecies = 0; ispecies < nspecies; ispecies++) {
-        species_entropy[ispecies] -= this->Rs[ispecies]*log(temperature*species_densities[ispecies]*this->density_ref);
-    }
+    std::array<real,nspecies> species_entropy = compute_species_entropy(conservative_soln);
     std::array<real,nspecies> species_Cp = compute_species_specific_Cp(temperature);
 
     std::array<real, nspecies> species_gibbs;
@@ -703,6 +719,7 @@ std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
     return species_gibbs;
 }
 
+// Compute the entropy variables from conservative solution
 template <int dim, int nspecies, int nstate, typename real>
 std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
 ::compute_entropy_variables (
@@ -732,6 +749,7 @@ std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
     return entropy_var;
 }
 
+// Map entropy variables back to conservative solution
 template <int dim, int nspecies, int nstate, typename real>
 std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
 ::compute_conservative_variables_from_entropy_variables (
@@ -764,9 +782,9 @@ std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
     const std::array<real,nspecies> Rs = compute_Rs(this->Ru);
     conservative_var[0] = 0.0;
     for(int ispecies = 0; ispecies < nspecies; ++ispecies) {
-        std::array<real,nspecies> entropy_nasa_data = compute_species_entropy(temperature);
+        std::array<real,nspecies> species_entropy_integral = compute_species_entropy_cv_integral(temperature);
 
-        species_density[ispecies] = (exp((entropy_nasa_data[ispecies] - species_entropy[ispecies])/(Rs[ispecies])))/(temperature*this->density_ref);
+        species_density[ispecies] = (exp((species_entropy_integral[ispecies] - species_entropy[ispecies])/(Rs[ispecies])))/(temperature*this->density_ref);
         conservative_var[0] += species_density[ispecies];
 
         if (dim + 2 + ispecies < nstate)

--- a/src/physics/real_gas.cpp
+++ b/src/physics/real_gas.cpp
@@ -162,26 +162,6 @@ std::array<int,nspecies>  RealGas<dim, nspecies, nstate, real>
 }
 
 template <int dim, int nspecies, int nstate, typename real>
-std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
-::compute_entropy_variables (
-    const std::array<real,nstate> &conservative_soln) const
-{
-    this->pcout<<"Entropy variables for RealGas hasn't been done yet."<<std::endl;
-    std::abort();
-    return conservative_soln;
-}
-
-template <int dim, int nspecies, int nstate, typename real>
-std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
-::compute_conservative_variables_from_entropy_variables (
-    const std::array<real,nstate> &entropy_var) const
-{
-    this->pcout<<"Entropy variables for RealGas hasn't been done yet."<<std::endl;
-    std::abort();
-    return entropy_var;
-}
-
-template <int dim, int nspecies, int nstate, typename real>
 std::array<real,nstate> RealGas<dim,nspecies,nstate,real>
 ::convective_eigenvalues (
     const std::array<real,nstate> &conservative_soln,
@@ -572,10 +552,10 @@ std::array<real,nspecies> RealGas<dim,nspecies,nstate,real>
 ::compute_species_specific_enthalpy ( const real temperature ) const
 {
     real dimensional_temperature = compute_dimensional_temperature(temperature);
-    std::array<real,nspecies>h;
+    std::array<real,nspecies> h;
     
     if (dimensional_temperature < 0) {
-        std::cout<<"Enthalpy Calculation Error: Temperature passed in is negative... Temperature = " << dimensional_temperature << "...Aborting." << std::endl;
+        std::cout<<"Species Enthalpy Calculation Error: Temperature passed in is negative... Temperature = " << dimensional_temperature << "...Aborting." << std::endl;
         std::abort();
     }
     std::array<int,nspecies> species_tempindex = GetNASACAP_TemperatureIndex(dimensional_temperature);
@@ -641,6 +621,184 @@ std::array<real,nspecies> RealGas<dim,nspecies,nstate,real>
     }
 
     return e;
+}
+
+template <int dim, int nspecies, int nstate, typename real>
+std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
+::compute_species_entropy ( 
+    const real temperature) const
+{
+    real dimensional_temperature = compute_dimensional_temperature(temperature);
+    std::array<real,nspecies> species_entropy;
+
+    if (dimensional_temperature < 0) {
+        std::cout<<" Species Entropy Calculation Error: Temperature passed in is negative... Temperature = " << dimensional_temperature << "...Aborting." << std::endl;
+        std::abort();
+    }    
+    std::array<int,nspecies> species_tempindex = GetNASACAP_TemperatureIndex(dimensional_temperature);
+    
+    /// species loop
+    for (int s=0; s<nspecies; ++s) 
+    { 
+        // main computation
+        real Cp = 0.0;
+        real out_of_bounds_temp = -1.0;
+        if(species_tempindex[s] == -1) { // Calculate entropy using calorically perfect gas (CPG) model (Refer to NASA FUN3D manual v14.2 sec.B.8)
+            species_tempindex[s] = 0;
+            std::array<real,nspecies> Cp_species = compute_species_specific_Cp(NASACAPTemperatureLimits[s][0]);
+            Cp = Cp_species[s]; // obtain Cp so the entropy can be calculated with CPG model
+            Cp /= this->Rs[s]; // nondimensional molar value of Cp;
+            out_of_bounds_temp = dimensional_temperature; // save the temperature value to calculate entropy using CPG model
+            dimensional_temperature = NASACAPTemperatureLimits[s][0];
+        }
+        if(species_tempindex[s] == 3) { // Calculate entropy using calorically perfect gas (CPG) model (Refer to NASA FUN3D manual v14.2 sec.B.8)
+            species_tempindex[s] = 2;
+            std::array<real,nspecies> Cp_species = compute_species_specific_Cp(NASACAPTemperatureLimits[s][2]);
+            Cp = Cp_species[s]; // obtain Cp so the entropy can be calculated with CPG model
+            Cp /= this->Rs[s]; // nondimensional molar value of Cp;
+            out_of_bounds_temp = dimensional_temperature; // save the temperature value to calculate entropy using CPG model
+            dimensional_temperature = NASACAPTemperatureLimits[s][2];
+        }
+        species_entropy[s] = -this->NASACAPCoeffs[s][0][species_tempindex[s]]*pow(dimensional_temperature,-2)*0.5
+                -this->NASACAPCoeffs[s][1][species_tempindex[s]]*pow(dimensional_temperature,-1) 
+                +this->NASACAPCoeffs[s][2][species_tempindex[s]]*log(dimensional_temperature)
+                +this->NASACAPCoeffs[s][8][species_tempindex[s]];
+        for (int i=3; i<7; i++)
+        {
+            species_entropy[s] += this->NASACAPCoeffs[s][i][species_tempindex[s]]*pow(dimensional_temperature,double(i-2))/((double)(i-2)); // The other terms are added
+        }
+
+        if(out_of_bounds_temp != -1.0) {
+            species_entropy[s] = species_entropy[s] + log(dimensional_temperature/out_of_bounds_temp) * Cp;
+        }
+
+        // set dimensional temp back to the out of bounds temp for the next species in the loop
+        if (out_of_bounds_temp != -1.0)
+            dimensional_temperature = out_of_bounds_temp;
+        species_entropy[s] *= this->Rs[s];
+    }
+
+    return species_entropy;
+}
+
+template <int dim, int nspecies, int nstate, typename real>
+std::array<real,nspecies> RealGas<dim, nspecies, nstate, real>
+::compute_species_gibbs_energy (
+    const std::array<real,nstate> &conservative_soln) const
+{
+    const real temperature = compute_temperature(conservative_soln);
+    const std::array<real,nspecies> species_densities = compute_species_densities(conservative_soln);
+
+    std::array<real,nspecies> species_entropy = compute_species_entropy(temperature);
+    for(int ispecies = 0; ispecies < nspecies; ispecies++) {
+        species_entropy[ispecies] -= this->Rs[ispecies]*log(temperature*species_densities[ispecies]*this->density_ref);
+    }
+    std::array<real,nspecies> species_Cp = compute_species_specific_Cp(temperature);
+
+    std::array<real, nspecies> species_gibbs;
+    for(int ispecies = 0; ispecies < nspecies; ++ispecies) {
+        species_gibbs[ispecies] = temperature*(species_Cp[ispecies] - species_entropy[ispecies]);
+    }
+
+    return species_gibbs;
+}
+
+template <int dim, int nspecies, int nstate, typename real>
+std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
+::compute_entropy_variables (
+    const std::array<real,nstate> &conservative_soln) const
+{
+    std::array<real,nstate> entropy_var;
+    const real temperature = compute_temperature(conservative_soln);
+    std::array<real,nspecies> species_gibbs = compute_species_gibbs_energy(conservative_soln);
+    real vel2 = compute_velocity_squared_from_conservative_solution(conservative_soln);
+
+    entropy_var[0] = species_gibbs[nspecies-1] - (0.5*vel2);
+    entropy_var[dim+1] = -1.0;
+
+    const dealii::Tensor<1,dim,real> vel = compute_velocities(conservative_soln);
+    for (int idim = 0; idim < dim; ++idim) {
+        entropy_var[idim+1] = vel[idim];
+    }
+
+    for (int ispecies = 0; ispecies < nspecies - 1; ++ispecies) {
+        entropy_var[dim+2+ispecies] = species_gibbs[ispecies] - species_gibbs[nspecies-1];
+    }
+
+    for (int istate = 0; istate < nstate; ++istate) {
+        entropy_var[istate] /= temperature;
+    }
+
+    return entropy_var;
+}
+
+template <int dim, int nspecies, int nstate, typename real>
+std::array<real,nstate> RealGas<dim, nspecies, nstate, real>
+::compute_conservative_variables_from_entropy_variables (
+    const std::array<real,nstate> &entropy_var) const
+{
+    std::array<real,nstate> conservative_var;
+    const real temperature = -1/entropy_var[dim+1];
+    const int nth_species_idx = nspecies - 1;
+
+    std::array<real,nspecies> species_gibbs;
+
+    real entropy_var_vel_squared = 0.0;
+    for(int idim=0; idim<dim; idim++){
+        entropy_var_vel_squared += pow(entropy_var[idim + 1]*temperature, 2.0);
+    }
+
+    species_gibbs[nth_species_idx] = temperature*entropy_var[0] + entropy_var_vel_squared/2.0;
+    for(int ispecies = 0; ispecies < nth_species_idx; ++ispecies) {
+        species_gibbs[ispecies] = temperature*entropy_var[dim+2+ispecies] + species_gibbs[nth_species_idx];
+    }
+
+    std::array<real,nspecies> species_entropy;
+    std::array<real,nspecies> species_Cp = compute_species_specific_Cp(temperature);
+    for(int ispecies = 0; ispecies < nth_species_idx; ++ispecies) {
+        species_entropy[ispecies] = species_Cp[ispecies] - (species_gibbs[ispecies]/temperature);
+    }
+    species_entropy[nth_species_idx] = species_Cp[nth_species_idx] - (species_gibbs[nth_species_idx]/temperature);
+
+    std::array<real,nspecies> species_density;
+    const std::array<real,nspecies> Rs = compute_Rs(this->Ru);
+    conservative_var[0] = 0.0;
+    for(int ispecies = 0; ispecies < nspecies; ++ispecies) {
+        std::array<real,nspecies> entropy_nasa_data = compute_species_entropy(temperature);
+
+        species_density[ispecies] = (exp((entropy_nasa_data[ispecies] - species_entropy[ispecies])/(Rs[ispecies])))/(temperature*this->density_ref);
+        conservative_var[0] += species_density[ispecies];
+
+        if (dim + 2 + ispecies < nstate)
+            conservative_var[dim+2+ispecies] = species_density[ispecies];
+    }
+
+    const real mixture_density = conservative_var[0];
+
+    for (int idim = 0; idim < dim; ++idim) {
+        conservative_var[idim+1] = mixture_density*entropy_var[idim+1]*temperature;
+    }
+    
+    // specific kinetic energy
+    const real specific_kinetic_energy = 0.50*entropy_var_vel_squared;
+    // species specific enthalpy
+    const std::array<real,nspecies> species_specific_enthalpy = compute_species_specific_enthalpy(temperature); 
+    std::array<real,nspecies> species_specific_internal_energy;
+    std::array<real,nspecies> species_specific_total_energy;
+    // species energy
+    for (int s=0; s<nspecies; ++s) 
+    { 
+      species_specific_internal_energy[s] = species_specific_enthalpy[s] - (this->R_ref*this->temperature_ref/this->u_ref_sqr)* Rs[s]*temperature;
+      species_specific_total_energy[s] =  species_specific_internal_energy[s] + specific_kinetic_energy;
+    }     
+    // mixture energy
+    real mixture_specific_total_energy = 0.0;
+    for(int ispecies = 0; ispecies < nspecies; ++ispecies) {
+        mixture_specific_total_energy += species_specific_total_energy[ispecies] *(species_density[ispecies]/mixture_density);
+    }
+    conservative_var[dim+1] = mixture_density*mixture_specific_total_energy;
+
+    return conservative_var;
 }
 
 // Algorithm 15 (f_M15): Compute temperature

--- a/src/physics/real_gas.h
+++ b/src/physics/real_gas.h
@@ -219,11 +219,14 @@ protected:
     // Algorithm 14 (f_M14): Compute species specific internal energy from temperature
     std::array<real,nspecies> compute_species_specific_internal_energy ( const real temperature ) const;
 
-    // Compute species entropy from temperature
+    // Compute Cv integral component of the species entropy equation
     // These are computed using the NASA 9-Coefficient Polynomial Parameterization (see McBride et. al, 2002) 
-    std::array<real,nspecies> compute_species_entropy ( const real temperature ) const; 
+    std::array<real,nspecies> compute_species_entropy_cv_integral ( const real temperature ) const; 
 
-    // Compute species Gibbs' energy from temperature and species density
+    // Compute species entropy from temperature and species density
+    std::array<real,nspecies> compute_species_entropy ( const std::array<real,nstate> &conservative_soln ) const;
+
+    // Compute species Gibbs' energy using species entropy and species Cp
     std::array<real,nspecies> compute_species_gibbs_energy ( const std::array<real,nstate> &conservative_soln ) const;
 public:
     // Algorithm 15 (f_M15): Compute temperature from conservative_soln

--- a/src/physics/real_gas.h
+++ b/src/physics/real_gas.h
@@ -215,6 +215,11 @@ protected:
     // Algorithm 14 (f_M14): Compute species specific internal energy from temperature
     std::array<real,nspecies> compute_species_specific_internal_energy ( const real temperature ) const;
 
+    // Compute species entropy from temperature
+    std::array<real,nspecies> compute_species_entropy ( const real temperature ) const; 
+
+    // Compute species Gibbs' energy from temperature and species density
+    std::array<real,nspecies> compute_species_gibbs_energy ( const std::array<real,nstate> &conservative_soln ) const;
 public:
     // Algorithm 15 (f_M15): Compute temperature from conservative_soln
     virtual real compute_temperature ( const std::array<real,nstate> &conservative_soln ) const;

--- a/src/physics/real_gas.h
+++ b/src/physics/real_gas.h
@@ -202,6 +202,7 @@ public:
 
 protected:
     // Algorithm 11 (f_M11): Compute species specific heat at constant pressure from temperature
+    // These are computed using the NASA 9-Coefficient Polynomial Parameterization (see McBride et. al, 2002) 
     // Modified by Shruthi
     std::array<real,nspecies> compute_species_specific_Cp ( const real temperature ) const;
 
@@ -209,6 +210,7 @@ protected:
     std::array<real,nspecies>compute_species_specific_Cv ( const real temperature ) const;
 
     // Algorithm 13 (f_M13): Compute species specific enthalpy from temperature
+    // These are computed using the NASA 9-Coefficient Polynomial Parameterization (see McBride et. al, 2002) 
     // Modified by Shruthi
     std::array<real,nspecies> compute_species_specific_enthalpy ( const real temperature ) const;   
 
@@ -216,6 +218,7 @@ protected:
     std::array<real,nspecies> compute_species_specific_internal_energy ( const real temperature ) const;
 
     // Compute species entropy from temperature
+    // These are computed using the NASA 9-Coefficient Polynomial Parameterization (see McBride et. al, 2002) 
     std::array<real,nspecies> compute_species_entropy ( const real temperature ) const; 
 
     // Compute species Gibbs' energy from temperature and species density

--- a/src/physics/real_gas.h
+++ b/src/physics/real_gas.h
@@ -11,6 +11,9 @@ namespace PHiLiP {
 namespace Physics {
 
 /// RealGas equations. Derived from PhysicsBase
+/* Functions designated with "// Algorithm # (f_M#)" are detailed in Matsuyama's M.Sc. thesis (2025)
+   Algorithms that have "Modified by Shruthi" appended to it do not strictly follow the implementation in the thesis*/
+
 template <int dim, int nspecies, int nstate, typename real>
 class RealGas : public PhysicsBase <dim, nspecies, nstate, real>
 {
@@ -157,7 +160,6 @@ public:
         const std::array<real,nstate> &primitive_soln,
         const std::array<dealii::Tensor<1,dim,real>,nstate> &primitive_soln_gradient) const;
         
-// Details of the following algorithms are presented in Liki's Master's thesis.
 /* MAIN FUNCTIONS */
 protected:
     // Algorithm 1 (f_M1): Compute mixture density from conservative_soln

--- a/tests/integration_tests_control_files/ms_sod_shock_tube/1D_ms_sod_shock_tube.prm
+++ b/tests/integration_tests_control_files/ms_sod_shock_tube/1D_ms_sod_shock_tube.prm
@@ -10,7 +10,7 @@ set chemistry_input_file = ../../chemistry_files/O2_N2.kinetics
 set run_type = flow_simulation
 
 # DG formulation
-set use_weak_form = true
+set use_weak_form = false
 set flux_nodes_type = GLL
 set conv_num_flux = lax_friedrichs
 
@@ -50,7 +50,7 @@ subsection flow_solver
     set grid_left_bound = 0.0
     set grid_right_bound = 1.0
     subsection grid_rectangle
-      set number_of_grid_elements_x = 400
+      set number_of_grid_elements_x = 100
     end
   end
 end

--- a/tests/integration_tests_control_files/ms_sod_shock_tube/CMakeLists.txt
+++ b/tests/integration_tests_control_files/ms_sod_shock_tube/CMakeLists.txt
@@ -1,22 +1,22 @@
-#set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # =======================================
 # 1D Multispecies Sod Shock Tube test
 # =======================================
-#if(${NUMBER_OF_SPECIES} EQUAL 2)
-#configure_file(1D_ms_sod_shock_tube.prm 1D_ms_sod_shock_tube.prm COPYONLY)
-#add_test(
-#  NAME 1D_MULTISPECIES_SOD_SHOCK_TUBE_TEST
-#  COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_ms_sod_shock_tube.prm
-#  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
-#)
-#set_tests_labels(1D_MULTISPECIES_SOD_SHOCK_TUBE_TEST 	MS_SOD_SHOCK_TUBE
-#														1D
-#														SERIAL
-#														MULTISPECIES
-#														RUNGE-KUTTA
-#														COLLOCATED
-#														LIMITER
-#														QUICK
-#														INTEGRATION_TEST)
-#endif()
+if(${NUMBER_OF_SPECIES} EQUAL 2)
+configure_file(1D_ms_sod_shock_tube.prm 1D_ms_sod_shock_tube.prm COPYONLY)
+add_test(
+  NAME 1D_MULTISPECIES_SOD_SHOCK_TUBE_TEST
+  COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_1D -i ${CMAKE_CURRENT_BINARY_DIR}/1D_ms_sod_shock_tube.prm
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+set_tests_labels(1D_MULTISPECIES_SOD_SHOCK_TUBE_TEST 	MS_SOD_SHOCK_TUBE
+														1D
+														SERIAL
+														MULTISPECIES
+														RUNGE-KUTTA
+														COLLOCATED
+														LIMITER
+														QUICK
+														INTEGRATION_TEST)
+endif()

--- a/tests/unit_tests/euler_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/euler_unit_test/CMakeLists.txt
@@ -42,6 +42,49 @@ foreach(dim RANGE 1 3)
 endforeach()
 
 set(TEST_SRC
+    euler_convert_entropy_var_conservative.cpp
+    )
+
+foreach(dim RANGE 1 3)
+
+    # Output executable
+    string(CONCAT TEST_TARGET ${dim}D_euler_convert_entropy_var_conservative)
+    message("Adding executable " ${TEST_TARGET} " with files " ${TEST_SRC} "\n")
+    add_executable(${TEST_TARGET} ${TEST_SRC})
+    # Replace occurences of PHILIP_DIM with 1, 2, or 3 in the code
+    target_compile_definitions(${TEST_TARGET} PRIVATE PHILIP_DIM=${dim})
+    # Replace occurences of PHILIP_SPECIES with user-defined value in the code
+    target_compile_definitions(${TEST_TARGET} PRIVATE PHILIP_SPECIES=${NUMBER_OF_SPECIES})
+
+    # Compile this executable when 'make unit_tests'
+    add_dependencies(unit_tests ${TEST_TARGET})
+    add_dependencies(${dim}D ${TEST_TARGET})
+
+    # Library dependency
+    string(CONCAT PhysicsLib Physics_${dim}D)
+    target_link_libraries(${TEST_TARGET} ${PhysicsLib})
+    # Setup target with deal.II
+    if (NOT DOC_ONLY)
+        DEAL_II_SETUP_TARGET(${TEST_TARGET})
+    endif()
+
+    add_test(
+      NAME ${TEST_TARGET}
+      COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
+      WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+    )
+    set_tests_labels(${TEST_TARGET} EULER_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
+
+    unset(TEST_TARGET)
+    unset(PhysicsLib)
+
+endforeach()
+
+set(TEST_SRC
     euler_manufactured_solution_source.cpp
     )
 

--- a/tests/unit_tests/euler_unit_test/euler_convert_entropy_var_conservative.cpp
+++ b/tests/unit_tests/euler_unit_test/euler_convert_entropy_var_conservative.cpp
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include "assert_compare_array.h"
+#include "parameters/parameters.h"
+#include "physics/euler.h"
+
+const double TOLERANCE = 1E-12;
+
+
+int main (int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+    const int dim = PHILIP_DIM;
+    const int nspecies = 1;
+    const int nstate = dim+2;
+
+    //const double ref_length = 1.0, mach_inf=1.0, angle_of_attack = 0.0, side_slip_angle = 0.0, gamma_gas = 1.4;
+    const double a = 1.0 , b = 0.0, c = 1.4;
+    //default parameters
+    dealii::ParameterHandler parameter_handler;
+    PHiLiP::Parameters::AllParameters::declare_parameters (parameter_handler); // default fills options
+    PHiLiP::Parameters::AllParameters all_parameters;
+    all_parameters.parse_parameters (parameter_handler);
+    PHiLiP::Physics::Euler<dim, nspecies, nstate, double> euler_physics = PHiLiP::Physics::Euler<dim, nspecies, nstate, double>(&all_parameters,a,c,a,b,b);
+
+    const double min = 0.0;
+    const double max = 1.0;
+    const int nx = 11;
+
+    std::vector<unsigned int> repetitions(dim, nx);
+    dealii::Point<dim,double> corner1, corner2;
+    for (int d=0; d<dim; d++) { 
+        corner1[d] = min;
+        corner2[d] = max;
+    }
+    dealii::Triangulation<dim> grid;
+    dealii::GridGenerator::subdivided_hyper_rectangle(grid, repetitions, corner1, corner2);
+
+    std::array<double, dim+2> conservative_soln;
+    std::array<double, dim+2> conservative_soln2;
+    std::array<double, dim+2> entropy_variables;
+    for (auto cell : grid.active_cell_iterators()) {
+        for (unsigned int v=0; v < dealii::GeometryInfo<dim>::vertices_per_cell; ++v) {
+            const dealii::Point<dim,double> vertex = cell->vertex(v);
+            for (int s=0; s<nstate; s++) {
+                conservative_soln[s] = euler_physics.manufactured_solution_function->value(vertex, s);
+            }
+            entropy_variables = euler_physics.compute_entropy_variables(conservative_soln);
+            conservative_soln2 = euler_physics.compute_conservative_variables_from_entropy_variables(entropy_variables);
+
+            // Flipping back and forth between conservative and primitive solution result
+            // in the same solution
+            assert_compare_array<nstate> ( conservative_soln, conservative_soln2, 1.0, TOLERANCE);
+            // Manufactured solution gives positive density
+            if(conservative_soln[0] < TOLERANCE) std::abort();
+            // Manufactured solution gives positive energy
+            if(conservative_soln[nstate-1] < TOLERANCE) std::abort();
+
+            if(euler_physics.compute_pressure(conservative_soln) < TOLERANCE) std::abort();
+            if(euler_physics.compute_sound(conservative_soln) < TOLERANCE) std::abort();
+
+        }
+    }
+    MPI_Finalize();
+    return 0;
+}
+

--- a/tests/unit_tests/real_gas_unit_test/CMakeLists.txt
+++ b/tests/unit_tests/real_gas_unit_test/CMakeLists.txt
@@ -40,3 +40,46 @@ foreach(dim RANGE 1 3)
     unset(PhysicsLib)
 
 endforeach()
+
+set(TEST_SRC
+    real_gas_convert_entropy_var_conservative.cpp
+    )
+
+foreach(dim RANGE 1 3)
+
+    # Output executable
+    string(CONCAT TEST_TARGET ${dim}D_real_gas_convert_entropy_var_conservative)
+    message("Adding executable " ${TEST_TARGET} " with files " ${TEST_SRC} "\n")
+    add_executable(${TEST_TARGET} ${TEST_SRC})
+    # Replace occurences of PHILIP_DIM with 1, 2, or 3 in the code
+    target_compile_definitions(${TEST_TARGET} PRIVATE PHILIP_DIM=${dim})
+    # Replace occurences of PHILIP_SPECIES with user-defined value in the code
+    target_compile_definitions(${TEST_TARGET} PRIVATE PHILIP_SPECIES=${NUMBER_OF_SPECIES})
+
+    # Compile this executable when 'make unit_tests'
+    add_dependencies(unit_tests ${TEST_TARGET})
+    add_dependencies(${dim}D ${TEST_TARGET})
+
+    # Library dependency
+    string(CONCAT PhysicsLib Physics_${dim}D)
+    target_link_libraries(${TEST_TARGET} ${PhysicsLib})
+    # Setup target with deal.II
+    if (NOT DOC_ONLY)
+        DEAL_II_SETUP_TARGET(${TEST_TARGET})
+    endif()
+
+    add_test(
+      NAME ${TEST_TARGET}
+      COMMAND mpirun -n 1 ${EXECUTABLE_OUTPUT_PATH}/${TEST_TARGET}
+      WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+    )
+    set_tests_labels(${TEST_TARGET} REAL_GAS_UNIT_TEST
+                                    ${dim}D
+                                    SERIAL
+                                    QUICK
+                                    UNIT_TEST)
+
+    unset(TEST_TARGET)
+    unset(PhysicsLib)
+
+endforeach()

--- a/tests/unit_tests/real_gas_unit_test/real_gas_convert_entropy_var_conservative.cpp
+++ b/tests/unit_tests/real_gas_unit_test/real_gas_convert_entropy_var_conservative.cpp
@@ -1,0 +1,79 @@
+#include <assert.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include "assert_compare_array.h"
+#include "parameters/parameters.h"
+#include "physics/real_gas.h"
+
+const double TOLERANCE = 1E-12;
+
+
+int main (int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+    const int dim = PHILIP_DIM;
+    const int nspecies = PHILIP_SPECIES;
+    const int nstate = dim+nspecies+1;
+
+    //default parameters
+    dealii::ParameterHandler parameter_handler;
+    PHiLiP::Parameters::AllParameters::declare_parameters (parameter_handler); // default fills options
+    PHiLiP::Parameters::AllParameters all_parameters;
+    all_parameters.parse_parameters (parameter_handler);
+
+    all_parameters.euler_param.mach_inf = 1.0; all_parameters.euler_param.gamma_gas = 1.4;
+    if (nspecies == 2)
+        all_parameters.chemistry_input_file = "../../chemistry_files/O2_N2.kinetics";
+    else if (nspecies == 3)
+        all_parameters.chemistry_input_file = "../../chemistry_files/H2_O2_N2.kinetics";
+
+    using ManufacturedSolutionEnum = PHiLiP::Parameters::ManufacturedSolutionParam::ManufacturedSolutionType;
+    all_parameters.manufactured_convergence_study_param.manufactured_solution_param.manufactured_solution_type = ManufacturedSolutionEnum::atan_solution;
+    PHiLiP::Physics::RealGas<dim, nspecies, nstate, double> real_gas_physics = PHiLiP::Physics::RealGas<dim, nspecies, nstate, double>(&all_parameters);
+
+    const double min = 0.0;
+    const double max = 1.0;
+    const int nx = 11;
+
+    std::vector<unsigned int> repetitions(dim, nx);
+    dealii::Point<dim,double> corner1, corner2;
+    for (int d=0; d<dim; d++) { 
+        corner1[d] = min;
+        corner2[d] = max;
+    }
+    dealii::Triangulation<dim> grid;
+    dealii::GridGenerator::subdivided_hyper_rectangle(grid, repetitions, corner1, corner2);
+
+    std::array<double, dim+nspecies+1> conservative_soln;
+    std::array<double, dim+nspecies+1> conservative_soln2;
+    std::array<double, dim+nspecies+1> entropy_variables;
+    for (auto cell : grid.active_cell_iterators()) {
+        for (unsigned int v=0; v < dealii::GeometryInfo<dim>::vertices_per_cell; ++v) {
+            const dealii::Point<dim,double> vertex = cell->vertex(v);
+            for (int s=0; s<nstate; s++) {
+                conservative_soln[s] = real_gas_physics.manufactured_solution_function->value(vertex, s);
+            }
+            entropy_variables = real_gas_physics.compute_entropy_variables(conservative_soln);
+            conservative_soln2 = real_gas_physics.compute_conservative_variables_from_entropy_variables(entropy_variables);
+
+            // Flipping back and forth between conservative and primitive solution result
+            // in the same solution
+            assert_compare_array<nstate> ( conservative_soln, conservative_soln2, 1.0, TOLERANCE);
+            // Manufactured solution gives positive density
+            if(conservative_soln[0] < TOLERANCE) std::abort();
+            // Manufactured solution gives positive energy
+            if(conservative_soln[dim+1] < TOLERANCE) std::abort();
+            
+            // Manufactured solution gives positive species densities
+            for(int ispecies = 0; ispecies < nspecies - 1; ++ispecies)
+                if(conservative_soln[dim+2+ispecies] < TOLERANCE) std::abort();
+
+            if(real_gas_physics.compute_mixture_pressure(conservative_soln) < TOLERANCE) std::abort();
+            if(real_gas_physics.compute_sound(conservative_soln) < TOLERANCE) std::abort();
+
+        }
+    }
+    MPI_Finalize();
+    return 0;
+}
+


### PR DESCRIPTION
This PR allows users to run Real Gas simulations using Strong DG. The required functions for Strong DG to run are:

- `compute_entropy_variables`
- `compute_conservative_variables_from_entropy_variables`

Both of which are implemented in this PR. To compute the entropy variables, the following functions were also added:

- `compute_species_entropy`
- `compute_species_gibbs_energy`

Strong DG for Real Gas simulations is verified using the 1D Multi-species Vortex Advection case with 2 species which produces the same orders as the Weak DG run: 
[weak-strong-dg-comparison-ms-va-2s-lt.txt](https://github.com/user-attachments/files/27060445/weak-strong-dg-comparison-ms-va-2s-lt.txt)

The Multi-species Sod Shock Tube test case using Strong DG has also been included in the ctest suite.

Finally, 2 new unit tests have been added! One unit test is implemented to verify the conversion from entropy variables to conservative variables and back for Real Gas. The second unit test is identical to the first but is implemented for Euler. The new unit tests in ctest are:

- `{dim}D_real_gas_convert_entropy_var_conservative`
- `{dim}D_euler_convert_entropy_var_conservative`
