### PR TITLE
Change CMake error messages to refer to new script name

### DIFF
--- a/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/setup_files/1proc/CMakeLists.txt
+++ b/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/setup_files/1proc/CMakeLists.txt
@@ -4,7 +4,6 @@ set (filename "setup_philip-00000.dat")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
     message(SEND_ERROR
             "Missing flow initialization files named ${filename}.
-             Please run PHiLiP/get_flow_initialization_files_local.sh or 
-             PHiLiP/get_flow_initialization_files_cluster.sh if compiling on the cluster."
+             Please run PHiLiP/get_large_test_files.sh."
             )
 endif()

--- a/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/setup_files/4proc/CMakeLists.txt
+++ b/tests/integration_tests_control_files/decaying_homogeneous_isotropic_turbulence/setup_files/4proc/CMakeLists.txt
@@ -7,8 +7,7 @@ set (filename "setup_philip-00000.dat")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
     message(SEND_ERROR
             "Missing flow initialization files named ${filename}.
-             Please run PHiLiP/get_flow_initialization_files_local.sh or 
-             PHiLiP/get_flow_initialization_files_cluster.sh if compiling on the cluster."
+             Please run PHiLiP/get_large_test_files.sh."
             )
 endif()
 
@@ -16,8 +15,7 @@ set (filename "setup_philip-00001.dat")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
     message(SEND_ERROR
             "Missing flow initialization files named ${filename}.
-             Please run PHiLiP/get_flow_initialization_files_local.sh or 
-             PHiLiP/get_flow_initialization_files_cluster.sh if compiling on the cluster."
+             Please run PHiLiP/get_large_test_files.sh."
             )
 endif()
 
@@ -25,8 +23,7 @@ set (filename "setup_philip-00002.dat")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
     message(SEND_ERROR
             "Missing flow initialization files named ${filename}.
-             Please run PHiLiP/get_flow_initialization_files_local.sh or 
-             PHiLiP/get_flow_initialization_files_cluster.sh if compiling on the cluster."
+             Please run PHiLiP/get_large_test_files.sh."
             )
 endif()
 
@@ -34,7 +31,6 @@ set (filename "setup_philip-00003.dat")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
     message(SEND_ERROR
             "Missing flow initialization files named ${filename}.
-             Please run PHiLiP/get_flow_initialization_files_local.sh or 
-             PHiLiP/get_flow_initialization_files_cluster.sh if compiling on the cluster."
+             Please run PHiLiP/get_large_test_files.sh."
             )
 endif()

--- a/tests/meshes/CMakeLists.txt
+++ b/tests/meshes/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1QOYxwyo4MMZasTiRnayHCnZ4E8oMR0gL?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 
@@ -52,7 +52,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1QOYxwyo4MMZasTiRnayHCnZ4E8oMR0gL?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 
@@ -62,6 +62,6 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download them from
    https://drive.google.com/drive/folders/1QOYxwyo4MMZasTiRnayHCnZ4E8oMR0gL?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()

--- a/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
+++ b/tests/unit_tests/grid/gmsh_reader/CMakeLists.txt
@@ -71,7 +71,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing NACA0012 mesh file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -93,7 +93,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing NACA0012 mesh file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -115,7 +115,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -137,7 +137,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download them from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -158,7 +158,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download it from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -180,7 +180,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download it from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)
@@ -202,7 +202,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
 "Missing 3D GMSH file named ${filename}. Please download it from
     https://drive.google.com/drive/folders/1Z89Qq940bP9WwBr1Y5YVhZSAErOM0Rg6?usp=sharing
 and place them in
-      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_gmsh_mesh_files_local.sh"
+      ${CMAKE_CURRENT_SOURCE_DIR}, or simply run get_large_test_files.sh"
       )
 endif()
 configure_file(${filename} ${filename} COPYONLY)


### PR DESCRIPTION
Follow up from #333 

The script name was changed, but when the user does not have mesh/initialization files, the error message pointed to the old script names. 