### PR TITLE
Entropy Stable Viscous BR2 without auxiliary

### DIFF
--- a/src/dg/dg_base.cpp
+++ b/src/dg/dg_base.cpp
@@ -516,7 +516,7 @@ void DGBase<dim,nspecies,real,MeshType>::assemble_cell_residual_and_ad_derivativ
     {
         if(this->use_auxiliary_eq)
         {
-            pcout<<"ERROR: Implicit does not currently work for strong form with Auxiliary Equation. The added terms dR/dq * dq/du needs to be added. Aborting..."<<std::endl;
+            pcout<<"ERROR: Implicit does not currently work for strong form with Auxiliary Equation. Use strong form with entropy stable viscous DG instead. Aborting..."<<std::endl;
         }
         else
         {

--- a/src/dg/dg_base_state.cpp
+++ b/src/dg/dg_base_state.cpp
@@ -193,7 +193,9 @@ void DGBaseState<dim,nspecies,nstate,real,MeshType>::set_unsteady_model_time_ste
 
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 void DGBaseState<dim, nspecies, nstate, real, MeshType>::set_use_auxiliary_eq() {
-    this->use_auxiliary_eq = (pde_physics_double->has_nonzero_diffusion && !this->all_parameters->use_weak_form) ? true : false;
+    this->use_auxiliary_eq = (pde_physics_double->has_nonzero_diffusion && 
+                              !this->all_parameters->use_weak_form &&
+                              !this->all_parameters->use_viscous_br2_entropystable) ? true : false;
 }
 
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1139,7 +1139,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     //For conservative DG, we compute the reference flux as per Eq. (9), to then recover the second volume integral in Eq. (17).
     //For curvilinear split-form in Eq. (22), we apply a two-pt flux of the metric-cofactor matrix on the matrix operator constructed by the entropy stable/conservtive 2pt flux.
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> conv_ref_flux_at_q;
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_q;
     std::array<std::vector<adtype>,nstate> source_at_q;
     std::array<std::vector<adtype>,nstate> physical_source_at_q;
 
@@ -1257,11 +1256,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
             conv_phys_flux = pde_physics.convective_flux (soln_state);
         }
 
-        //Diffusion
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
-        //Compute the physical dissipative flux
-        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
-
         // Manufactured source
         std::array<adtype,nstate> manufactured_source;
         if(this->all_parameters->manufactured_convergence_study_param.manufactured_solution_param.use_manufactured_source_term) {
@@ -1287,7 +1281,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         //Write the values in a way that we can use sum-factorization on.
         for(int istate=0; istate<nstate; istate++){
             dealii::Tensor<1,dim,adtype> conv_ref_flux;
-            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
             //Trnasform to reference fluxes
             if (this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form){
                 //Do Nothing. 
@@ -1303,11 +1296,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
                     metric_cofactor,
                     conv_ref_flux);
             }
-            //transform the dissipative flux to reference space
-            metric_oper.transform_physical_to_reference(
-                diffusive_phys_flux[istate],
-                metric_cofactor,
-                diffusive_ref_flux);
 
             //Write the data in a way that we can use sum-factorization on.
             //Since sum-factorization improves the speed for matrix-vector multiplications,
@@ -1316,7 +1304,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
                 //allocate
                 if(iquad == 0){
                     conv_ref_flux_at_q[istate][idim].resize(n_quad_pts);
-                    diffusive_ref_flux_at_q[istate][idim].resize(n_quad_pts);
                 }
                 //write data
                 if (this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form){
@@ -1325,9 +1312,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
                 else{
                     conv_ref_flux_at_q[istate][idim][iquad] = conv_ref_flux[idim];
                 }
-
-                diffusive_ref_flux_at_q[istate][idim][iquad] = diffusive_ref_flux[idim];
             }
+
             if(this->all_parameters->manufactured_convergence_study_param.manufactured_solution_param.use_manufactured_source_term) {
                 if(iquad == 0){
                     source_at_q[istate].resize(n_quad_pts);
@@ -1363,7 +1349,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
 
         //Compute reference divergence of the reference fluxes.
         std::vector<adtype> conv_flux_divergence(n_quad_pts); 
-        std::vector<adtype> diffusive_flux_divergence(n_quad_pts); 
 
         if (this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form){
             //2pt flux Hadamard Product, and then multiply by vector of ones scaled by 1.
@@ -1392,11 +1377,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
                                                         flux_basis.oneD_vol_operator,
                                                         flux_basis.oneD_grad_operator);
         }
-        //Reference divergence of the reference diffusive flux.
-        flux_basis.divergence_matrix_vector_mult_1D(diffusive_ref_flux_at_q[istate], diffusive_flux_divergence,
-                                                    flux_basis.oneD_vol_operator,
-                                                    flux_basis.oneD_grad_operator);
-
 
         // Strong form
         // The right-hand side sends all the term to the side of the source term
@@ -1416,11 +1396,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         else {
             soln_basis.inner_product_1D(conv_flux_divergence, vol_quad_weights, rhs, soln_basis.oneD_vol_operator, false, -1.0);
         }
-
-        // Diffusive
-        // Note that for diffusion, the negative is defined in the physics. Since we used the auxiliary
-        // variable, put a negative here.
-        soln_basis.inner_product_1D(diffusive_flux_divergence, vol_quad_weights, rhs, soln_basis.oneD_vol_operator, true, -1.0);
 
         // Manufactured source
         if(this->all_parameters->manufactured_convergence_study_param.manufactured_solution_param.use_manufactured_source_term) {
@@ -1616,9 +1591,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
     const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
     std::vector<adtype>     &vol_term_viscous) const
 {
+    vol_term_viscous.reinit(n_dofs_cell);   
     if(this->all_parameters->use_viscous_br2_entropystable)
     {
-        vol_term_viscous.reinit(n_dofs_cell);   
         EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_volume_term_entropystable_br2(
         poly_degree,
         entropy_var_coeff,
@@ -1636,6 +1611,73 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
     }
     else
     {
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_q;
+        for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad)
+        {
+            for(int istate=0; istate<nstate; istate++){
+                soln_state[istate] = soln_at_q[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_q[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state[istate][idim] = aux_soln_at_q[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_q[istate][idim][iquad];
+                }
+            }
+
+            dealii::Tensor<2,dim,adtype> metric_cofactor;
+            for(int idim=0; idim<dim; idim++){
+                for(int jdim=0; jdim<dim; jdim++){
+                    metric_cofactor[idim][jdim] = metric_oper.metric_cofactor_vol[idim][jdim][iquad];
+                }
+            }
+
+            if (this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form){
+                //get the soln for iquad from projected entropy variables
+                std::array<adtype,nstate> entropy_var;
+                for(int istate=0; istate<nstate; istate++){
+                    entropy_var[istate] = entropy_var_at_q[istate][iquad];
+                }
+                soln_state = pde_physics.compute_conservative_variables_from_entropy_variables (entropy_var);
+            }
+        
+            //Diffusion
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
+            //Compute the physical dissipative flux
+            diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
+            for(int istate=0; istate<nstate; istate++){
+                dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
+                //transform the dissipative flux to reference space
+                metric_oper.transform_physical_to_reference(
+                diffusive_phys_flux[istate],
+                metric_cofactor,
+                diffusive_ref_flux);
+                
+                for(int idim=0; idim<dim; idim++){
+                    //allocate
+                    if(iquad == 0){
+                        diffusive_ref_flux_at_q[istate][idim].resize(n_quad_pts);
+                    }
+                    diffusive_ref_flux_at_q[istate][idim][iquad] = diffusive_ref_flux[idim];
+                }
+            } //istate loop ends
+        } // quad loop ends
+             
+        for(int istate=0; istate<nstate; istate++){
+            std::vector<adtype> diffusive_flux_divergence(n_quad_pts);             
+        
+             //Reference divergence of the reference diffusive flux.
+            flux_basis.divergence_matrix_vector_mult_1D(diffusive_ref_flux_at_q[istate], diffusive_flux_divergence,
+                                                        flux_basis.oneD_vol_operator,
+                                                        flux_basis.oneD_grad_operator);
+            // Diffusive
+            // Note that for diffusion, the negative is defined in the physics. Since we used the auxiliary
+            // variable, put a negative here.
+            std::vector<adtype> rhs(n_shape_fns);
+            soln_basis.inner_product_1D(diffusive_flux_divergence, vol_quad_weights, rhs, soln_basis.oneD_vol_operator, false, -1.0);
+            for(unsigned int ishape = 0; ishape<n_shape_fns; ++ishape)
+            {
+                vol_term_viscous[istate*n_shape_fns+ishape] = rhs[ishape];
+            }
+        }
     }
 }
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -3751,6 +3751,167 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_physic
                                                                 entropy_var_phys_grad[s]);
     }
 }
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::apply_diffusion_matrix_entropy_based(
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
+        const unsigned int                                                 n_quad_pts,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_in,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out) const
+{
+    //Resize
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            T_out[s][d].resize(n_quad_pts);
+        }
+    }
+
+    for(unsigned int q = 0; q<n_quad_pts; ++q)
+    {
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> T_in_at_q;
+        std::array<adtype,nstate> entropy_var_at_q;
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                T_in_at_q[s][d] = T_in[s][d][q];
+            }
+            entropy_var_at_q[s] = entropy_var_at_quads[s][q];
+        }
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> T_out_at_q = pde_physics.dissipative_flux_entropy_based(entropy_var_at_q, T_in_at_q);
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                T_out[s][d][q] = T_out_at_q[s][d];
+            }
+        }
+    }
+}
+
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
+    const unsigned int                                                 n_quad_pts,
+    const unsigned int                                                 n_dofs_cell,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+    const std::vector<double>                                          &weight_vect,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_input,
+    std::vector<adtype>                                                &integral_val) const
+{
+    const unsigned int n_shape_fns = n_dofs_cell / nstate; 
+    
+    // Form L = K*T
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   L;
+    apply_diffusion_matrix_entropy_based(
+    entropy_var_at_quads,
+    n_quad_pts,
+    pde_physics,
+    T_input,
+    L);
+
+    // Form M = cof(J)^T*L
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   M;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        metric_oper.transform_physical_to_reference_vector(
+            L[s],
+            metric_oper.metric_cofactor_vol,
+            M[s]);
+    }
+
+    // Compute \int_k nabla basis * K*T d\Omega
+    integral_val.resize(n_dofs_cell);
+    std::vector<adtype> integral_val_1state(n_shape_fns);
+
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+
+        soln_basis.inner_product(
+        M[s][0],
+        weight_vect,
+        integral_val_1state,
+        soln_basis.oneD_grad_operator,
+        soln_basis.oneD_vol_operator,
+        soln_basis.oneD_vol_operator,
+        false);
+
+        if(dim>=2)
+        {
+            soln_basis.inner_product(
+            M[s][1],
+            weight_vect,
+            integral_val_1state,
+            soln_basis.oneD_vol_operator,
+            soln_basis.oneD_grad_operator,
+            soln_basis.oneD_vol_operator,
+            true);
+        }
+
+
+        if(dim>=3)
+        {
+            soln_basis.inner_product(
+            M[s][2],
+            weight_vect,
+            integral_val_1state,
+            soln_basis.oneD_vol_operator,
+            soln_basis.oneD_vol_operator,
+            soln_basis.oneD_grad_operator,
+            true);
+        }
+
+        // Put values in integral_val vector.
+        const unsigned int start_index = s*n_shape_fns;
+        for(unsigned int ishape=0; ishape<n_shape_fns; ++ishape)
+        {
+            integral_val[start_index + ishape] = integral_val_1state[ishape];
+        }
+    }
+
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_entropystable_br2(
+    const unsigned int                                                 poly_degree,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_q,
+    const unsigned int                                                  n_quad_pts,
+    const unsigned int                                                  n_dofs_cell,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    std::vector<adtype>                                                &vol_term) const
+{
+    const std::vector<double> &weight_vect = this->volume_quadrature_collection[poly_degree].get_weights();
+    // Entropy grad wrt physical coordinates
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_phys_grad;
+    compute_physical_grad_entropy_var(
+       entropy_var_coeff,
+       soln_basis,
+       metric_oper,
+       n_quad_pts,
+       entropy_var_phys_grad);
+
+    compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+        entropy_var_at_q,
+        n_quad_pts,
+        n_dofs_cell,
+        soln_basis,
+        metric_oper,
+        weight_vect,
+        pde_physics,
+        entropy_var_phys_grad,
+        vol_term); 
+}
 
 
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1779,6 +1779,10 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     if(this->do_compute_filtered_solution) {
         // NOTE: This only pertains to advanced SGS models for LES
         compute_filtered_solution_volume_and_face(
+        legendre_soln_at_vol_q,
+        legendre_aux_soln_at_vol_q,
+        legendre_soln_at_surf_q,
+        legendre_aux_soln_at_surf_q,
         soln_at_vol_q, 
         aux_soln_at_vol_q,
         pde_physics,
@@ -2236,15 +2240,19 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volume_and_face(
+    std::array<std::vector<adtype>,nstate> &legendre_soln_at_vol_q,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
+    std::array<std::vector<adtype>,nstate> &legendre_soln_at_surf_q,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q,
     const std::array<std::vector<adtype>,nstate> &soln_at_vol_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
-    pde_physics,
+    Physics::PhysicsBase<dim, nspecies, nstate, adtype>                &pde_physics,
     const std::array<std::vector<adtype>,nstate> &soln_at_surf_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
-    n_quad_pts_vol,
-    n_face_quad_pts,
-    n_shape_fns,
-    poly_degree)
+    const unsigned int n_quad_pts_vol,
+    const unsigned int n_face_quad_pts,
+    const unsigned int n_shape_fns,
+    const unsigned int poly_degree)
 {
     // NOTE: This only pertains to advanced SGS models for LES
     //==================================================
@@ -2573,354 +2581,34 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> legendre_aux_soln_at_surf_q_ext; // legendre auxiliary sol at flux nodes
     if(this->do_compute_filtered_solution) {
         // NOTE: This only pertains to advanced SGS models for LES
-        //==================================================
-        // GET THE PRIMITIVE SOLUTION
-        //==================================================
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_vol_q_int;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_vol_q_int;
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_surf_q_int;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_surf_q_int;
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_vol_q_ext;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_vol_q_ext;
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_surf_q_ext;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_surf_q_ext;
-        // Resize the primitive soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            primitive_soln_at_vol_q_int[istate].resize(n_quad_pts_vol_int);
-            primitive_soln_at_surf_q_int[istate].resize(n_face_quad_pts);
-            primitive_soln_at_vol_q_ext[istate].resize(n_quad_pts_vol_ext);
-            primitive_soln_at_surf_q_ext[istate].resize(n_face_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                primitive_aux_soln_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
-                primitive_aux_soln_at_surf_q_int[istate][idim].resize(n_face_quad_pts);
-                primitive_aux_soln_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
-                primitive_aux_soln_at_surf_q_ext[istate][idim].resize(n_face_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        // -- volume int
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol_int; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_vol_q_int[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_vol_q_int[istate][idim][iquad];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_vol_q_int[istate][iquad] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_vol_q_int[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- volume ext
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol_ext; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_vol_q_ext[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_vol_q_ext[istate][idim][iquad];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_vol_q_ext[istate][iquad] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_vol_q_ext[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface int
-        for(unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++){
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_surf_q_int[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_surf_q_int[istate][idim][iquad_face];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_surf_q_int[istate][iquad_face] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_surf_q_int[istate][idim][iquad_face] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface ext
-        for(unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++){
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_surf_q_ext[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_surf_q_ext[istate][idim][iquad_face];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_surf_q_ext[istate][iquad_face] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_surf_q_ext[istate][idim][iquad_face] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-
-        //==================================================
-        // PROJECT TO LEGENDRE BASIS AND MODALLY FILTER
-        //==================================================
-        // -- Primitive solution at legendre poly
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_vol_q_int;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_vol_q_int;
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_surf_q_int;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_surf_q_int;
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_vol_q_ext;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_vol_q_ext;
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_surf_q_ext;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_surf_q_ext;
-
-        // Details: this projects to Legendre basis, truncates, then interpolates back to quad nodes.
-        // -- Constructor for tensor product polynomials based on Polynomials::Legendre interpolation. 
-        dealii::FE_DGQLegendre<1,1> legendre_poly_1D_int(poly_degree_int);
-        dealii::FE_DGQLegendre<1,1> legendre_poly_1D_ext(poly_degree_ext);
-        // -- Projection operator for legendre basis
-        OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper_int(1, poly_degree_int, this->max_grid_degree);
-        legendre_soln_basis_projection_oper_int.build_1D_volume_operator(legendre_poly_1D_int, this->oneD_quadrature_collection[poly_degree_int]);
-        OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper_ext(1, poly_degree_ext, this->max_grid_degree);
-        legendre_soln_basis_projection_oper_ext.build_1D_volume_operator(legendre_poly_1D_ext, this->oneD_quadrature_collection[poly_degree_ext]);
-        // -- Legendre basis functions 
-        OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis_int(1, poly_degree_int, this->max_grid_degree);
-        legendre_soln_basis_int.build_1D_volume_operator(legendre_poly_1D_int, this->oneD_quadrature_collection[poly_degree_int]);
-        legendre_soln_basis_int.build_1D_surface_operator(legendre_poly_1D_int, this->oneD_face_quadrature);
-        OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis_ext(1, poly_degree_ext, this->max_grid_degree);
-        legendre_soln_basis_ext.build_1D_volume_operator(legendre_poly_1D_ext, this->oneD_quadrature_collection[poly_degree_ext]);
-        legendre_soln_basis_ext.build_1D_surface_operator(legendre_poly_1D_ext, this->oneD_face_quadrature);
-        const unsigned int p_min_filtered = this->poly_degree_max_large_scales + 1;
-        for(int istate=0; istate<nstate; istate++){
-            //==================================================
-            // Solution
-            //==================================================
-            // -- (1) Project to Legendre basis
-            std::vector<adtype> legendre_soln_coeff_int(n_shape_fns_int);
-            legendre_soln_basis_projection_oper_int.matrix_vector_mult_1D(primitive_soln_at_vol_q_int[istate], legendre_soln_coeff_int,
-                                                                          legendre_soln_basis_projection_oper_int.oneD_vol_operator);
-            std::vector<adtype> legendre_soln_coeff_ext(n_shape_fns_ext);
-            legendre_soln_basis_projection_oper_ext.matrix_vector_mult_1D(primitive_soln_at_vol_q_ext[istate], legendre_soln_coeff_ext,
-                                                                          legendre_soln_basis_projection_oper_ext.oneD_vol_operator);
-            // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-            if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
-                    if(ishape < p_min_filtered){
-                        legendre_soln_coeff_int[ishape] = 0.0;
-                    }
-                }
-                for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
-                    if(ishape < p_min_filtered){
-                        legendre_soln_coeff_ext[ishape] = 0.0;
-                    }
-                }
-            }
-            // -- (3) Interpolate filtered solution back to quadrature points
-            primitive_legendre_soln_at_vol_q_int[istate].resize(n_quad_pts_vol_int);
-            legendre_soln_basis_int.matrix_vector_mult_1D(legendre_soln_coeff_int, primitive_legendre_soln_at_vol_q_int[istate],
-                                                          legendre_soln_basis_int.oneD_vol_operator);
-            primitive_legendre_soln_at_surf_q_int[istate].resize(n_face_quad_pts);
-            legendre_soln_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, iface,
-                                                                  legendre_soln_coeff_int, primitive_legendre_soln_at_surf_q_int[istate],
-                                                                  legendre_soln_basis_int.oneD_surf_operator,
-                                                                  legendre_soln_basis_int.oneD_vol_operator);
-            primitive_legendre_soln_at_vol_q_ext[istate].resize(n_quad_pts_vol_ext);
-            legendre_soln_basis_ext.matrix_vector_mult_1D(legendre_soln_coeff_ext, primitive_legendre_soln_at_vol_q_ext[istate],
-                                                          legendre_soln_basis_ext.oneD_vol_operator);
-            primitive_legendre_soln_at_surf_q_ext[istate].resize(n_face_quad_pts);
-            legendre_soln_basis_ext.matrix_vector_mult_surface_1D(face_orientation_ext, neighbor_iface,
-                                                                  legendre_soln_coeff_ext, primitive_legendre_soln_at_surf_q_ext[istate],
-                                                                  legendre_soln_basis_ext.oneD_surf_operator,
-                                                                  legendre_soln_basis_ext.oneD_vol_operator);
-            //==================================================
-
-            //==================================================
-            // Auxiliary Solution (gradients)
-            //==================================================
-            dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff_int;
-            dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff_ext;
-            for(int idim=0; idim<dim; idim++){
-                // -- (1) Project to Legendre basis
-                legendre_aux_soln_coeff_int[idim].resize(n_shape_fns_int);
-                legendre_aux_soln_coeff_ext[idim].resize(n_shape_fns_ext);
-                if(this->use_auxiliary_eq){
-                    legendre_soln_basis_projection_oper_int.matrix_vector_mult_1D(primitive_aux_soln_at_vol_q_int[istate][idim], legendre_aux_soln_coeff_int[idim],
-                                                                                  legendre_soln_basis_projection_oper_int.oneD_vol_operator);
-                    legendre_soln_basis_projection_oper_ext.matrix_vector_mult_1D(primitive_aux_soln_at_vol_q_ext[istate][idim], legendre_aux_soln_coeff_ext[idim],
-                                                                                  legendre_soln_basis_projection_oper_ext.oneD_vol_operator);
-                    // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-                    if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                        for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
-                            if(ishape < p_min_filtered){
-                                legendre_aux_soln_coeff_int[idim][ishape] = 0.0;
-                            }
-                        }
-                        for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
-                            if(ishape < p_min_filtered){
-                                legendre_aux_soln_coeff_ext[idim][ishape] = 0.0;
-                            }
-                        }
-                    }
-                }
-                else {
-                    for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
-                        legendre_aux_soln_coeff_int[idim][ishape] = 0.0;
-                    }
-                    for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
-                        legendre_aux_soln_coeff_ext[idim][ishape] = 0.0;
-                    }
-                }
-                // -- (3) Interpolate filtered solution back to quadrature points
-                primitive_legendre_aux_soln_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
-                legendre_soln_basis_int.matrix_vector_mult_1D(legendre_aux_soln_coeff_int[idim], primitive_legendre_aux_soln_at_vol_q_int[istate][idim],
-                                                              legendre_soln_basis_int.oneD_vol_operator);
-                primitive_legendre_aux_soln_at_surf_q_int[istate][idim].resize(n_face_quad_pts);
-                legendre_soln_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, iface,
-                                                                      legendre_aux_soln_coeff_int[idim], primitive_legendre_aux_soln_at_surf_q_int[istate][idim],
-                                                                      legendre_soln_basis_int.oneD_surf_operator,
-                                                                      legendre_soln_basis_int.oneD_vol_operator);
-                primitive_legendre_aux_soln_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
-                legendre_soln_basis_ext.matrix_vector_mult_1D(legendre_aux_soln_coeff_ext[idim], primitive_legendre_aux_soln_at_vol_q_ext[istate][idim],
-                                                              legendre_soln_basis_ext.oneD_vol_operator);
-                primitive_legendre_aux_soln_at_surf_q_ext[istate][idim].resize(n_face_quad_pts);
-                legendre_soln_basis_ext.matrix_vector_mult_surface_1D(face_orientation_ext, neighbor_iface,
-                                                                      legendre_aux_soln_coeff_ext[idim], primitive_legendre_aux_soln_at_surf_q_ext[istate][idim],
-                                                                      legendre_soln_basis_ext.oneD_surf_operator,
-                                                                      legendre_soln_basis_ext.oneD_vol_operator);
-            }
-            //==================================================
-        }
-        //=======================================================
-        // CONVERT PRIMITIVE LEGENDRE SOLUTION TO CONSERVATIVE
-        //=======================================================
-        // Resize the conservative soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            legendre_soln_at_vol_q_int[istate].resize(n_quad_pts_vol_int);
-            legendre_soln_at_surf_q_int[istate].resize(n_face_quad_pts);
-            legendre_soln_at_vol_q_ext[istate].resize(n_quad_pts_vol_ext);
-            legendre_soln_at_surf_q_ext[istate].resize(n_face_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                legendre_aux_soln_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
-                legendre_aux_soln_at_surf_q_int[istate][idim].resize(n_face_quad_pts);
-                legendre_aux_soln_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
-                legendre_aux_soln_at_surf_q_ext[istate][idim].resize(n_face_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        // -- volume int
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol_int; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_vol_q_int[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_vol_q_int[istate][idim][iquad];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_vol_q_int[istate][iquad] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_vol_q_int[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- volume ext
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol_ext; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_vol_q_ext[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_vol_q_ext[istate][idim][iquad];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_vol_q_ext[istate][iquad] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_vol_q_ext[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface int
-        for (unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_surf_q_int[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_surf_q_int[istate][idim][iquad_face];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_surf_q_int[istate][iquad_face] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_surf_q_int[istate][idim][iquad_face] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface ext
-        for (unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_surf_q_ext[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_surf_q_ext[istate][idim][iquad_face];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_surf_q_ext[istate][iquad_face] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_surf_q_ext[istate][idim][iquad_face] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
+        compute_filtered_solution_volume_and_face(
+            legendre_soln_at_vol_q_int,
+            legendre_aux_soln_at_vol_q_int,
+            legendre_soln_at_surf_q_int,
+            legendre_aux_soln_at_surf_q_int,
+            soln_at_vol_q_int,
+            aux_soln_at_vol_q_int,
+            pde_physics,
+            soln_at_surf_q_int,
+            aux_soln_at_surf_q_int,
+            n_quad_pts_vol_int,
+            n_face_quad_pts,
+            n_shape_fns_int,
+            poly_degree_int);
+        compute_filtered_solution_volume_and_face(
+            legendre_soln_at_vol_q_ext,
+            legendre_aux_soln_at_vol_q_ext,
+            legendre_soln_at_surf_q_ext,
+            legendre_aux_soln_at_surf_q_ext,
+            soln_at_vol_q_ext,
+            aux_soln_at_vol_q_ext,
+            pde_physics,
+            soln_at_surf_q_ext,
+            aux_soln_at_surf_q_ext,
+            n_quad_pts_vol_ext,
+            n_face_quad_pts,
+            n_shape_fns_ext,
+            poly_degree_ext);
     }
 
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1106,10 +1106,12 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     //get entropy projected variables
     std::array<std::vector<adtype>,nstate> entropy_var_at_q;
     std::array<std::vector<adtype>,nstate> projected_entropy_var_at_q;
+    std::array<std::vector<adtype>,nstate> entropy_var_coeffs;
     if (this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form){
         for(int istate=0; istate<nstate; istate++){
             entropy_var_at_q[istate].resize(n_quad_pts);
             projected_entropy_var_at_q[istate].resize(n_quad_pts);
+            entropy_var_coeffs[istate].resize(n_shape_fns);
         }
         for(unsigned int iquad=0; iquad<n_quad_pts; iquad++){
             std::array<adtype,nstate> soln_state;
@@ -1123,11 +1125,10 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
             }
         }
         for(int istate=0; istate<nstate; istate++){
-            std::vector<adtype> entropy_var_coeff(n_shape_fns);;
             soln_basis_projection_oper.matrix_vector_mult_1D(entropy_var_at_q[istate],
-                                                             entropy_var_coeff,
+                                                             entropy_var_coeffs[istate],
                                                              soln_basis_projection_oper.oneD_vol_operator);
-            soln_basis.matrix_vector_mult_1D(entropy_var_coeff,
+            soln_basis.matrix_vector_mult_1D(entropy_var_coeffs[istate],
                                              projected_entropy_var_at_q[istate],
                                              soln_basis.oneD_vol_operator);
         }
@@ -1163,16 +1164,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
         //extract soln and auxiliary soln at quad pt to be used in physics
         std::array<adtype,nstate> soln_state;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-        std::array<adtype,nstate> filtered_soln_state;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
         for(int istate=0; istate<nstate; istate++){
             soln_state[istate] = soln_at_q[istate][iquad];
-            if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_q[istate][iquad];
-            for(int idim=0; idim<dim; idim++){
-                aux_soln_state[istate][idim] = aux_soln_at_q[istate][idim][iquad];
-                if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_q[istate][idim][iquad];
-            }
         }
 
         // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
@@ -1422,6 +1415,29 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         }
 
     }
+    
+    std::vector<adtype> viscous_rhs_vol;
+    assemble_volume_term_viscous_primal(
+    current_cell_index,
+    soln_at_q,
+    aux_soln_at_q,
+    legendre_soln_at_q,
+    legendre_aux_soln_at_q,
+    poly_degree,
+    soln_basis,
+    flux_basis,
+    metric_oper,
+    entropy_var_coeffs,
+    projected_entropy_var_at_q,
+    n_quad_pts,
+    n_dofs_cell,
+    pde_physics,
+    viscous_rhs_vol);
+
+    for(unsigned int idof = 0; idof<n_dofs_cell; ++idof)
+    {
+        local_rhs_int_cell[idof] += viscous_rhs_vol[idof];
+    }
 }
     
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
@@ -1578,8 +1594,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volu
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_primal(
-    const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_coeff,
+    const dealii::types::global_dof_index                              current_cell_index,
+    const std::array<std::vector<adtype>,nstate> &soln_at_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q,
+    const std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
     const unsigned int                            poly_degree,
     OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
     OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
@@ -1611,9 +1630,14 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
     }
     else
     {
+        const std::vector<double> &vol_quad_weights = this->volume_quadrature_collection[poly_degree].get_weights();
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_q;
         for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad)
         {
+            std::array<adtype,nstate> soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+            std::array<adtype,nstate> filtered_soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
             for(int istate=0; istate<nstate; istate++){
                 soln_state[istate] = soln_at_q[istate][iquad];
                 if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_q[istate][iquad];
@@ -1953,22 +1977,23 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     //project it onto the solution basis functions and interpolate it
     std::array<std::vector<adtype>,nstate> projected_entropy_var_vol;
     std::array<std::vector<adtype>,nstate> projected_entropy_var_surf;
+    std::array<std::vector<adtype>,nstate> entropy_var_coeffs;
     for(int istate=0; istate<nstate; istate++){
         // allocate
         projected_entropy_var_vol[istate].resize(n_quad_pts_vol);
         projected_entropy_var_surf[istate].resize(n_face_quad_pts);
+        entropy_var_coeffs[istate].resize(n_shape_fns);
 
         //interior
-        std::vector<adtype> entropy_var_coeff(n_shape_fns);
         soln_basis_projection_oper.matrix_vector_mult_1D(entropy_var_vol[istate],
-                                                         entropy_var_coeff,
+                                                         entropy_var_coeffs[istate],
                                                          soln_basis_projection_oper.oneD_vol_operator);
-        soln_basis.matrix_vector_mult_1D(entropy_var_coeff,
+        soln_basis.matrix_vector_mult_1D(entropy_var_coeffs[istate],
                                          projected_entropy_var_vol[istate],
                                          soln_basis.oneD_vol_operator);
         soln_basis.matrix_vector_mult_surface_1D(face_orientation, 
                                                  iface,
-                                                 entropy_var_coeff, 
+                                                 entropy_var_coeffs[istate], 
                                                  projected_entropy_var_surf[istate],
                                                  soln_basis.oneD_surf_operator,
                                                  soln_basis.oneD_vol_operator);
@@ -2099,8 +2124,10 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     }//end of if split form or curvilinear split form
 
 
-    //the outward reference normal dircetion.
+    //the outward reference normal direction.
     std::array<std::vector<adtype>,nstate> conv_flux_dot_normal;
+    std::vector<dealii::Tensor<1,dim,adtype>> unit_phys_normals(n_face_quad_pts);
+    std::vector<adtype> JxW_face(n_face_quad_pts);
     // Get surface numerical fluxes
     for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
         // Copy Metric Cofactor on the facet in a way can use for transforming Tensor Blocks to reference space
@@ -2124,7 +2151,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
             face_Jac_norm_scaled += unit_phys_normal_int[idim] * unit_phys_normal_int[idim];
         }
         face_Jac_norm_scaled = sqrt(face_Jac_norm_scaled);
+        JxW_face[iquad] = face_Jac_norm_scaled*face_quad_weights[iquad];
         unit_phys_normal_int /= face_Jac_norm_scaled;//normalize it. 
+        unit_phys_normals[iquad] = unit_phys_normal_int;
 
         //get the projected entropy variables, soln, and 
         //auxiliary solution on the surface point.
@@ -2132,14 +2161,12 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
         std::array<adtype,nstate> soln_interp_to_face;
         std::array<adtype,nstate> soln_state;
-        std::array<adtype,nstate> opposite_surf_soln_state;
         std::array<adtype,nstate> filtered_soln_state;
         std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
         for(int istate=0; istate<nstate; istate++){
             soln_interp_to_face[istate] = soln_at_surf_q[istate][iquad];
             soln_state[istate] = soln_interp_to_face[istate]; // initialize as solution interpolated to face
             entropy_var_face[istate] = projected_entropy_var_surf[istate][iquad];
-            if(this->using_wall_model && (boundary_id == 1001)) opposite_surf_soln_state[istate] = soln_at_opposite_surf_q[istate][iquad];
             if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_surf_q[istate][iquad];
             for(int idim=0; idim<dim; idim++){
                 aux_soln_state[istate][idim] = aux_soln_at_surf_q[istate][idim][iquad];
@@ -2218,17 +2245,75 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
             local_rhs_cell[istate*n_shape_fns + ishape] += rhs[ishape];
         }
     }
+    
+    std::vector<adtype> boundary_term_viscous;
+    assemble_boundary_term_viscous_primal(
+        current_cell_index,
+        face_orientation,
+        iface,
+        boundary_id,
+        poly_degree,
+        entropy_var_coeffs,
+        projected_entropy_var_vol,
+        projected_entropy_var_surf,
+        soln_at_vol_q,
+        aux_soln_at_vol_q,
+        soln_at_surf_q,
+        aux_soln_at_surf_q,
+        soln_at_opposite_surf_q.
+        legendre_soln_at_vol_q,
+        legendre_aux_soln_at_vol_q,
+        legendre_soln_at_surf_q,
+        legendre_aux_soln_at_surf_q,
+        n_vol_quad_pts,  
+        n_face_quad_pts,  
+        n_dofs, 
+        soln_basis,
+        flux_basis,
+        metric_oper,
+        unit_phys_normals,
+        JxW_face,
+        pde_physics,
+        diss_num_flux,
+        boundary_term_viscous);
+
+    for(unsigned int idof=0; idof<n_dofs; ++idof)
+    {
+        local_rhs_cell[idof]+= boundary_term_viscous[idof];
+    }
 }
 
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous_primal(
-        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-        const unsigned int                            poly_degree,
-        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
-        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
-        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
-        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS)
+    const dealii::types::global_dof_index                              current_cell_index,
+    std::vector<bool>                                                  face_orientation,
+    const unsigned int                                                 iface,
+    const unsigned int                                                 boundary_id,
+    const unsigned int                                                 poly_degree,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q.
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q,
+    const unsigned int                                                 n_vol_quad_pts,  
+    const unsigned int                                                 n_face_quad_pts,  
+    const unsigned int                                                 n_dofs_cell, 
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+    const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normals,
+    const std::vector<adtype>                                          &JxW_face,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
+    std::vector<adtype>                                                &boundary_term_viscous) const
 {
     boundary_term_viscous.reinit(n_dofs_cell);   
     
@@ -2259,6 +2344,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
     }
     else
     {
+        const unsigned int n_shape_fns = n_dofs_cell / nstate; 
+        const std::vector<double> &face_quad_weights = this->face_quadrature_collection[poly_degree].get_weights();
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q;
         for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
             // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
@@ -2338,7 +2425,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
             for(int istate=0; istate<nstate; istate++){
                 soln_interp_to_face[istate] = soln_at_surf_q[istate][iquad];
                 soln_state[istate] = soln_interp_to_face[istate]; // initialize as solution interpolated to face
-                entropy_var_face[istate] = projected_entropy_var_surf[istate][iquad];
+                entropy_var_face[istate] = entropy_var_at_surf_quads[istate][iquad];
                 if(this->using_wall_model && (boundary_id == 1001)) opposite_surf_soln_state[istate] = soln_at_opposite_surf_q[istate][iquad];
                 if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_surf_q[istate][iquad];
                 for(int idim=0; idim<dim; idim++){
@@ -2361,7 +2448,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
             }
             
             // Dissipative numerical flux
-            pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
+            pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normals[iquad], soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
             std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
             if(this->using_wall_model && (boundary_id == 1001)) {
                 diss_auxi_num_flux_dot_n_at_q = pde_physics.dissipative_flux_dot_normal(
@@ -2369,7 +2456,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
                     filtered_soln_state, filtered_aux_soln_state,
                     true, // on_boundary == true
                     current_cell_index, 
-                    unit_phys_normal_int,
+                    unit_phys_normals[iquad],
                     boundary_id);
             } else {
                 diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
@@ -2379,7 +2466,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
                     aux_soln_state, grad_soln_boundary,
                     filtered_soln_state, soln_boundary,
                     filtered_aux_soln_state, grad_soln_boundary,
-                    unit_phys_normal_int, penalty, true, boundary_id);
+                    unit_phys_normals[iquad], penalty, true, boundary_id);
             }
             for(int istate=0; istate<nstate; istate++){
                 // allocate
@@ -2387,6 +2474,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
                     diss_flux_dot_normal_diff[istate].resize(n_face_quad_pts);
                 }
                 // write data
+                const adtype face_Jac_norm_scaled = JxW_face[iquad]/face_quad_weights[iquad];
                 diss_flux_dot_normal_diff[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate]
                                                          - diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate][iquad];
             }
@@ -2669,6 +2757,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
 {
 
     const unsigned int n_face_quad_pts = this->face_quadrature_collection[poly_degree_int].size();//assume interior cell does the work
+    const std::vector<double> &surf_quad_weights = this->face_quadrature_collection[poly_degree_int].get_weights();
 
     const unsigned int n_quad_pts_vol_int  = this->volume_quadrature_collection[poly_degree_int].size();
     const unsigned int n_quad_pts_vol_ext  = this->volume_quadrature_collection[poly_degree_ext].size();
@@ -2995,6 +3084,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     std::array<std::vector<adtype>,nstate> projected_entropy_var_surf_ext;
     std::array<std::vector<adtype>,nstate> projected_entropy_var_surf_int_corrected; //To be corrected for face orientation. Needed for numerical flux when using split form
     std::array<std::vector<adtype>,nstate> projected_entropy_var_surf_ext_corrected; //To be corrected for face orientation. Needed for numerical flux when using split form
+    std::array<std::vector<adtype>,nstate> entropy_var_coeffs_int;
+    std::array<std::vector<adtype>,nstate> entropy_var_coeffs_ext;
+
     for(int istate=0; istate<nstate; istate++){
         // allocate
         projected_entropy_var_vol_int[istate].resize(n_quad_pts_vol_int);
@@ -3003,48 +3095,48 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
         projected_entropy_var_surf_ext[istate].resize(n_face_quad_pts);
         projected_entropy_var_surf_int_corrected[istate].resize(n_face_quad_pts);
         projected_entropy_var_surf_ext_corrected[istate].resize(n_face_quad_pts);
+        entropy_var_coeffs_int[istate].resize(n_shape_fns_int);
+        entropy_var_coeffs_ext[istate].resize(n_shape_fns_ext);
 
         //interior
-        std::vector<adtype> entropy_var_coeff_int(n_shape_fns_int);
         soln_basis_projection_oper_int.matrix_vector_mult_1D(entropy_var_vol_int[istate],
-                                                             entropy_var_coeff_int,
+                                                             entropy_var_coeffs_int[istate],
                                                              soln_basis_projection_oper_int.oneD_vol_operator);
-        soln_basis_int.matrix_vector_mult_1D(entropy_var_coeff_int,
+        soln_basis_int.matrix_vector_mult_1D(entropy_var_coeffs_int[istate],
                                              projected_entropy_var_vol_int[istate],
                                              soln_basis_int.oneD_vol_operator);
         soln_basis_int.matrix_vector_mult_surface_1D({true,false,false}, 
                                                      iface,
-                                                     entropy_var_coeff_int, 
+                                                     entropy_var_coeffs_int[istate], 
                                                      projected_entropy_var_surf_int[istate],
                                                      soln_basis_int.oneD_surf_operator,
                                                      soln_basis_int.oneD_vol_operator);
 
         soln_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, 
                                                     iface,
-                                                    entropy_var_coeff_int, 
+                                                    entropy_var_coeffs_int[istate], 
                                                     projected_entropy_var_surf_int_corrected[istate],
                                                     soln_basis_int.oneD_surf_operator,
                                                     soln_basis_int.oneD_vol_operator);
 
         //exterior
-        std::vector<adtype> entropy_var_coeff_ext(n_shape_fns_ext);
         soln_basis_projection_oper_ext.matrix_vector_mult_1D(entropy_var_vol_ext[istate],
-                                                             entropy_var_coeff_ext,
+                                                             entropy_var_coeffs_ext[istate],
                                                              soln_basis_projection_oper_ext.oneD_vol_operator);
 
-        soln_basis_ext.matrix_vector_mult_1D(entropy_var_coeff_ext,
+        soln_basis_ext.matrix_vector_mult_1D(entropy_var_coeffs_ext[istate],
                                              projected_entropy_var_vol_ext[istate],
                                              soln_basis_ext.oneD_vol_operator);
         soln_basis_ext.matrix_vector_mult_surface_1D({true,false,false}, 
                                                      neighbor_iface,
-                                                     entropy_var_coeff_ext, 
+                                                     entropy_var_coeffs_ext[istate], 
                                                      projected_entropy_var_surf_ext[istate],
                                                      soln_basis_ext.oneD_surf_operator,
                                                      soln_basis_ext.oneD_vol_operator);
 
         soln_basis_int.matrix_vector_mult_surface_1D(face_orientation_ext, 
                                                     neighbor_iface,
-                                                    entropy_var_coeff_ext, 
+                                                    entropy_var_coeffs_ext[istate], 
                                                     projected_entropy_var_surf_ext_corrected[istate],
                                                     soln_basis_int.oneD_surf_operator,
                                                     soln_basis_int.oneD_vol_operator);
@@ -3263,6 +3355,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     // Evaluate reference numerical fluxes.
     
     std::array<std::vector<adtype>,nstate> conv_num_flux_dot_n;
+    std::vector<dealii::Tensor<1,dim,adtype>> unit_phys_normals_int(n_face_quad_pts);
+    std::vector<adtype> JxW_face(n_face_quad_pts);
     for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
         // Copy Metric Cofactor on the facet in a way can use for transforming Tensor Blocks to reference space
         // The way it is stored in metric_operators is to use sum-factorization in each direction,
@@ -3306,7 +3400,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             face_Jac_norm_scaled += unit_phys_normal_int[idim] * unit_phys_normal_int[idim];
         }
         face_Jac_norm_scaled = sqrt(face_Jac_norm_scaled);
-        unit_phys_normal_int /= face_Jac_norm_scaled;//normalize it. 
+        JxW_face[iquad] = face_Jac_norm_scaled*surf_quad_weights[iquad];
+        unit_phys_normal_int /= face_Jac_norm_scaled;//normalize it.
+        unit_phys_normals_int[iquad] = unit_phys_normal_int;
         // Note that the facet determinant of metric jacobian is the above norm multiplied by the determinant of the metric Jacobian evaluated on the facet.
         // Since the determinant of the metric Jacobian evaluated on the face cancels off, we can just scale the numerical flux by the norm.
         std::array<adtype,nstate> conv_num_flux_dot_n_at_q;
@@ -3330,7 +3426,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     }
 
     // Compute RHS
-    const std::vector<double> &surf_quad_weights = this->face_quadrature_collection[poly_degree_int].get_weights();
     for(int istate=0; istate<nstate; istate++){
         // interior RHS
         std::vector<adtype> rhs_int(n_shape_fns_int);
@@ -3415,20 +3510,121 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             local_rhs_ext_cell[istate*n_shape_fns_ext + ishape] += rhs_ext[ishape];
         }
     }
+
+    std::vector<adtype> viscous_face_term_int;
+    std::vector<adtype> viscous_face_term_ext;
+    assemble_face_term_viscous_primal(
+        current_cell_index,
+        neighbor_cell_index,
+        face_orientation_int,
+        face_orientation_ext,
+        iface,
+        neighbor_iface,
+        entropy_var_coeffs_int,
+        entropy_var_coeffs_ext,
+        projected_entropy_var_vol_int,
+        projected_entropy_var_vol_ext,
+        projected_entropy_var_surf_int_corrected,
+        projected_entropy_var_surf_ext_corrected,
+        soln_at_vol_q_int.
+        soln_at_vol_q_ext,
+        aux_soln_at_vol_q_int,
+        aux_soln_at_vol_q_ext,
+        soln_at_surf_q_int,
+        soln_at_surf_q_ext,
+        aux_soln_at_surf_q_int,
+        aux_soln_at_surf_q_ext;
+        legendre_soln_at_vol_q_int,
+        legendre_aux_soln_at_vol_q_int,
+        legendre_soln_at_vol_q_ext,
+        legendre_aux_soln_at_vol_q_ext, 
+        legendre_soln_at_surf_q_int,
+        legendre_aux_soln_at_surf_q_int,
+        legendre_soln_at_surf_q_ext,
+        legendre_aux_soln_at_surf_q_ext,
+        unit_phys_normals_int,
+        JxW_face,
+        poly_degree_int,
+        poly_degree_ext,
+        n_quad_pts_vol_int,
+        n_quad_pts_vol_ext,
+        n_dofs_int,
+        n_dofs_ext,
+        n_face_quad_pts,
+        soln_basis_int,
+        soln_basis_ext,
+        flux_basis_int,
+        flux_basis_ext,
+        metric_oper_int,
+        metric_oper_ext,
+        pde_physics,
+        diss_num_flux,
+        viscous_face_term_int,
+        viscous_face_term_ext);
+
+    for(unsigned int idof=0; idof<n_dofs_int; ++idof)
+    {
+        local_rhs_int_cell[idof] += viscous_face_term_int[idof];
+    }
+    for(unsigned int idof=0; idof<n_dofs_ext; ++idof)
+    {
+        local_rhs_ext_cell[idof] += viscous_face_term_ext[idof];
+    }
 }
 
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_primal(
-    const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-    const unsigned int                            poly_degree,
-    OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
-    OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
-    OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
-    dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS)
+    const dealii::types::global_dof_index                              current_cell_index,
+    const dealii::types::global_dof_index                              neighbor_cell_index,
+    std::vector<bool>                                                  face_orientation_int,
+    std::vector<bool>                                                  face_orientation_ext,
+    const unsigned int                                                 iface_int,
+    const unsigned int                                                 iface_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int.
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_ext,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_int,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_ext,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_int,
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_ext,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_int,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext;
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_int,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_int,
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_ext,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_ext, 
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q_int,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q_int,
+    const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q_ext,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q_ext,
+    const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal_int,
+    const std::vector<adtype>                                          &JxW_face,
+    const unsigned int                                                  poly_degree_int,
+    const unsigned int                                                  poly_degree_ext,
+    const unsigned int                                                  n_quad_pts_vol_int,
+    const unsigned int                                                  n_quad_pts_vol_ext,
+    const unsigned int                                                  n_dofs_cell_int,
+    const unsigned int                                                  n_dofs_cell_ext,
+    const unsigned int                                                  n_face_quad_pts,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
+    std::vector<adtype>                                                &viscous_face_term_int,
+    std::vector<adtype>                                                &viscous_face_term_ext) const
 {
-    face_term_int.resize(n_dofs_cell_int);
-    face_term_ext.resize(n_dofs_cell_ext);
+    viscous_face_term_int.resize(n_dofs_cell_int);
+    viscous_face_term_ext.resize(n_dofs_cell_ext);
     if(this->all_parameters->use_viscous_br2_entropystable)
     {
         EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_face_term_entropystable_br2(
@@ -3446,8 +3642,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
          JxW_face,
          poly_degree_int,
          poly_degree_ext,
-         n_vol_quad_pts_int,
-         n_vol_quad_pts_ext,
+         n_quad_pts_vol_int,
+         n_quad_pts_vol_ext,
          n_dofs_cell_int,
          n_dofs_cell_ext,
          n_face_quad_pts,
@@ -3458,16 +3654,16 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
          metric_oper_int,
          metric_oper_ext,
          pde_physics,
-         face_term_int,
-         face_term_ext);
+         viscous_face_term_int,
+         viscous_face_term_ext);
 
          for(unsigned int i=0; i<n_dofs_cell_int; ++i)
          {
-            face_term_int[i]*=-1.0;
+            viscous_face_term_int[i]*=-1.0;
          }
          for(unsigned int i=0; i<n_dofs_cell_ext; ++i)
          {
-            face_term_ext[i]*=-1.0;
+            viscous_face_term_ext[i]*=-1.0;
          }
     }
     else
@@ -3567,8 +3763,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
         const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
         const dealii::Tensor<1,dim,double> unit_ref_normal_ext = dealii::GeometryInfo<dim>::unit_normal_vector[neighbor_iface];
         // Extract the reference direction that is outward facing on the facet.
-        const int dim_not_zero_int = iface / 2;//reference direction of face integer division
-        const int dim_not_zero_ext = neighbor_iface / 2;//reference direction of face integer division
+        const int dim_not_zero_int = iface_int / 2;//reference direction of face integer division
+        const int dim_not_zero_ext = iface_ext / 2;//reference direction of face integer division
         
         std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
         std::array<std::vector<adtype>,nstate> diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal;
@@ -3582,14 +3778,14 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
             
             // interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
             flux_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, 
-                                                         iface,
+                                                         iface_int,
                                                          diffusive_ref_flux_at_vol_q_int[istate][dim_not_zero_int],
                                                          diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
                                                          flux_basis_int.oneD_surf_operator,
                                                          flux_basis_int.oneD_vol_operator,
                                                          false, unit_ref_normal_int[dim_not_zero_int]);
             flux_basis_ext.matrix_vector_mult_surface_1D(face_orientation_ext, 
-                                                         neighbor_iface,
+                                                         iface_ext,
                                                          diffusive_ref_flux_at_vol_q_ext[istate][dim_not_zero_ext],
                                                          diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
                                                          flux_basis_ext.oneD_surf_operator,
@@ -3615,8 +3811,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                 soln_interp_to_face_ext[istate] = soln_at_surf_q_ext[istate][iquad];
                 if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_int[istate] = legendre_soln_at_surf_q_int[istate][iquad];
                 if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_ext[istate] = legendre_soln_at_surf_q_ext[istate][iquad];
-                entropy_var_face_int[istate] = projected_entropy_var_surf_int_corrected[istate][iquad];
-                entropy_var_face_ext[istate] = projected_entropy_var_surf_ext_corrected[istate][iquad];
+                entropy_var_face_int[istate] = entropy_var_at_surf_int[istate][iquad];
+                entropy_var_face_ext[istate] = entropy_var_at_surf_ext[istate][iquad];
                 for(int idim=0; idim<dim; idim++){
                     aux_soln_state_int[istate][idim] = aux_soln_at_surf_q_int[istate][idim][iquad];
                     aux_soln_state_ext[istate][idim] = aux_soln_at_surf_q_ext[istate][idim][iquad];
@@ -3647,7 +3843,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                 aux_soln_state_int, aux_soln_state_ext,
                 filtered_soln_interp_to_face_int, filtered_soln_interp_to_face_ext,
                 filtered_aux_soln_state_int, filtered_aux_soln_state_ext,
-                unit_phys_normal_int, penalty, false);
+                unit_phys_normal_int[iquad], penalty, false);
 
             // Write the values in a way that we can use sum-factorization on.
             for(int istate=0; istate<nstate; istate++){
@@ -3655,7 +3851,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                 if(iquad == 0){
                     diss_auxi_num_flux_dot_n[istate].resize(n_face_quad_pts);
                 }
-
+                
+                const adtype face_Jac_norm_scaled = JxW_face[iquad]/surf_quad_weights[iquad];
                 // write data
                 diss_auxi_num_flux_dot_n[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate];
             }
@@ -3667,7 +3864,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
 
             // dissipative flux
             soln_basis_int.inner_product_surface_1D(face_orientation_int, 
-                                                    iface,
+                                                    iface_int,
                                                     diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
                                                     surf_quad_weights, rhs_int, 
                                                     soln_basis_int.oneD_surf_operator, 
@@ -3675,7 +3872,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                                                     false, 1.0);//subtract the negative so add it
             // dissipative numerical flux
             soln_basis_int.inner_product_surface_1D(face_orientation_int, 
-                                                    iface,
+                                                    iface_int,
                                                     diss_auxi_num_flux_dot_n[istate], 
                                                     surf_quad_weights, rhs_int, 
                                                     soln_basis_int.oneD_surf_operator, 
@@ -3692,7 +3889,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
 
             // dissipative flux
             soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
-                                                    neighbor_iface,
+                                                    iface_ext,
                                                     diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
                                                     surf_quad_weights, rhs_ext, 
                                                     soln_basis_ext.oneD_surf_operator, 
@@ -3700,7 +3897,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                                                     false, 1.0);
             // dissipative numerical flux
             soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
-                                                    neighbor_iface,
+                                                    iface_ext,
                                                     diss_auxi_num_flux_dot_n[istate], 
                                                     surf_quad_weights, rhs_ext, 
                                                     soln_basis_ext.oneD_surf_operator, 
@@ -3713,7 +3910,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
             }
         }
 
-    }// else 
+    } 
     
 }
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -3608,6 +3608,152 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::allocate_dual_vector(const boo
     }
 }
 
+//=========================================================================================================
+                //     Entropy Stable Viscous BR2 Scheme without auxiliary
+//=========================================================================================================
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::interpolate_to_face(
+    std::vector<bool> face_orientation,
+    const unsigned int iface,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_vol,
+    OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+    const unsigned int n_face_quad_pts,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face) const
+{
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            T_at_face[s][d].resize(n_face_quad_pts);
+        }
+    }
+
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            flux_basis.matrix_vector_mult_surface_1D(face_orientation,
+                                                     iface, 
+                                                     T_at_vol[s][d],
+                                                     T_at_face[s][d],
+                                                     flux_basis.oneD_surf_operator,
+                                                     flux_basis.oneD_vol_operator);
+        }
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::evaluate_face_integral(
+    std::vector<bool> face_orientation,
+    const unsigned int iface,
+    const std::array<std::vector<adtype>,nstate> &sigma_dot_n_at_face,
+    const std::vector<adtype> &JxW_face,
+    OPERATOR::basis_functions<dim,2*dim> &soln_basis,
+    const unsigned int n_dofs_cell,
+    std::vector<adtype> &integral_val) const
+{
+    integral_val.resize(n_dofs_cell); 
+    const unsigned int n_shape_fns = n_dofs_cell/nstate;
+
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        std::vector<adtype> integral_1state(n_shape_fns);
+        soln_basis.inner_product_surface_1D_JxW(face_orientation, iface, sigma_dot_n_at_face[s],
+                                            JxW_face, integral_1state,
+                                            soln_basis.oneD_surf_operator,
+                                            soln_basis.oneD_vol_operator);
+        const unsigned int start_index = s*n_shape_fns;
+        for(unsigned int ishape = 0; ishape<n_shape_fns; ++ishape)
+        {
+            integral_val[start_index + ishape] = integral_1state[ishape];
+        }
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_lift_polynomial(
+    std::vector<bool> face_orientation,
+    const unsigned int iface,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &phi_at_face,
+    const std::vector<adtype> &JxW_face,
+    const std::vector<adtype> &JxW_vol,
+    OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+    const unsigned int n_vol_quad_pts,
+    const bool is_interior_face,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol) const
+{
+    const unsigned int n_shape_fns_flux = n_vol_quad_pts; // collocated 
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            re_out_vol[s][d].resize(n_shape_fns_flux);
+        }
+    }
+
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            flux_basis.inner_product_surface_1D_JxW(face_orientation, iface,
+                                                phi_at_face[s][d],
+                                                JxW_face, re_out_vol[s][d],
+                                                flux_basis.oneD_surf_operator,
+                                                flux_basis.oneD_vol_operator);
+        }
+    }
+
+    const double mult_factor = is_interior_face ? 0.5 : 1.0;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            for(unsigned int iquad = 0; iquad<n_vol_quad_pts; ++iquad)
+            {
+                re_out_vol[s][d][iquad]*= -mult_factor/JxW_vol[iquad];
+            }
+        }
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_physical_grad_entropy_var(
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+    const unsigned int                                                 n_quad_pts,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad) const
+{
+    // Entropy grad wrt reference coordinates
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_ref_grad;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            entropy_var_ref_grad[s][d].resize(n_quad_pts);
+        }
+        soln_basis.gradient_matrix_vector_mult_1D(entropy_var_coeff[s],
+                                                  entropy_var_ref_grad[s],
+                                                  soln_basis.oneD_vol_operator,
+                                                  soln_basis.oneD_grad_operator);
+    }
+    
+    // Entropy grad wrt physical coordinates
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        metric_oper.transform_reference_to_physical_grad_vector(entropy_var_ref_grad[s],
+                                                                metric_oper.metric_cofactor_vol,
+                                                                metric_oper.det_Jac_vol,
+                                                                entropy_var_phys_grad[s]);
+    }
+}
+
+
+
 #if PHILIP_SPECIES==1
     // using default MeshType = Triangulation
 // 1D: dealii::Triangulation<dim>;

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1842,7 +1842,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
 
     // First we do interior.
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> conv_ref_flux_at_vol_q;
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q;
     for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
         // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
         // The way it is stored in metric_operators is to use sum-factorization in each direction,
@@ -1872,14 +1871,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
             conv_phys_flux = pde_physics.convective_flux (soln_state);
         }
 
-        // Compute the physical dissipative flux
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
-        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
-
         // Write the values in a way that we can use sum-factorization on.
         for(int istate=0; istate<nstate; istate++){
             dealii::Tensor<1,dim,adtype> conv_ref_flux;
-            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
             // transform the conservative convective physical flux to reference space
             if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                 metric_oper.transform_physical_to_reference(
@@ -1887,11 +1881,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
                     metric_cofactor_vol,
                     conv_ref_flux);
             }
-            // transform the dissipative flux to reference space
-            metric_oper.transform_physical_to_reference(
-                diffusive_phys_flux[istate],
-                metric_cofactor_vol,
-                diffusive_ref_flux);
 
             // Write the data in a way that we can use sum-factorization on.
             // Since sum-factorization improves the speed for matrix-vector multiplications,
@@ -1900,14 +1889,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
                 //allocate
                 if(iquad == 0){
                     conv_ref_flux_at_vol_q[istate][idim].resize(n_quad_pts_vol);
-                    diffusive_ref_flux_at_vol_q[istate][idim].resize(n_quad_pts_vol);
                 }
                 //write data
                 if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                     conv_ref_flux_at_vol_q[istate][idim][iquad] = conv_ref_flux[idim];
                 }
-
-                diffusive_ref_flux_at_vol_q[istate][idim][iquad] = diffusive_ref_flux[idim];
             }
         }
     }
@@ -1921,11 +1907,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     const int dim_not_zero = iface / 2;//reference direction of face integer division
 
     std::array<std::vector<adtype>,nstate> conv_int_vol_ref_flux_interp_to_face_dot_ref_normal;
-    std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
     for(int istate=0; istate<nstate; istate++){
         //allocate
         conv_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
-        diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
 
         //solve
         //Note, since the normal is zero in all other reference directions, we only have to interpolate one given reference direction to the facet
@@ -1941,14 +1925,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
                                                      false, unit_ref_normal_int[dim_not_zero]);//don't add to previous value, scale by unit_normal int
         }
 
-        //interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
-        flux_basis.matrix_vector_mult_surface_1D(face_orientation, 
-                                                 iface,
-                                                 diffusive_ref_flux_at_vol_q[istate][dim_not_zero],
-                                                 diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
-                                                 flux_basis.oneD_surf_operator,
-                                                 flux_basis.oneD_vol_operator,
-                                                 false, unit_ref_normal_int[dim_not_zero]);
     }
 
     //Note that for entropy-dissipation and entropy stability, the conservative variables
@@ -2125,7 +2101,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
 
     //the outward reference normal dircetion.
     std::array<std::vector<adtype>,nstate> conv_flux_dot_normal;
-    std::array<std::vector<adtype>,nstate> diss_flux_dot_normal_diff;
     // Get surface numerical fluxes
     for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
         // Copy Metric Cofactor on the facet in a way can use for transforming Tensor Blocks to reference space
@@ -2193,28 +2168,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         std::array<adtype,nstate> conv_num_flux_dot_n_at_q;
         conv_num_flux_dot_n_at_q = conv_num_flux.evaluate_flux(soln_state, soln_boundary, unit_phys_normal_int);
         
-        // Dissipative numerical flux
-        pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
-        std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
-        if(this->using_wall_model && (boundary_id == 1001)) {
-            diss_auxi_num_flux_dot_n_at_q = pde_physics.dissipative_flux_dot_normal(
-                opposite_surf_soln_state, aux_soln_state, 
-                filtered_soln_state, filtered_aux_soln_state,
-                true, // on_boundary == true
-                current_cell_index, 
-                unit_phys_normal_int,
-                boundary_id);
-        } else {
-            diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
-                current_cell_index, current_cell_index,
-                0.0, 0.0,
-                soln_interp_to_face, soln_boundary,
-                aux_soln_state, grad_soln_boundary,
-                filtered_soln_state, soln_boundary,
-                filtered_aux_soln_state, grad_soln_boundary,
-                unit_phys_normal_int, penalty, true, boundary_id);
-        }
-
         for(int istate=0; istate<nstate; istate++){
             // allocate
             if(iquad==0){
@@ -2278,6 +2231,154 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         }
     }
 }
+
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous_primal(
+        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+        const unsigned int                            poly_degree,
+        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS)
+{
+    boundary_term_viscous.reinit(n_dofs_cell);   
+    
+    if(this->all_parameters->use_viscous_br2_entropystable)
+    {
+        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_entropystable_br2(
+        face_orientation,
+        iface,
+        boundary_id,
+        poly_degree,
+        entropy_var_coeff,
+        entropy_var_at_vol_quads,
+        entropy_var_at_surf_quads,
+        n_vol_quad_pts,
+        n_face_quad_pts,
+        n_dofs_cell,
+        soln_basis,
+        flux_basis,
+        metric_oper,
+        unit_phys_normal,
+        JxW_face,
+        pde_physics,
+        boundary_term_viscous);
+        for(unsigned int i=0; i<n_dofs_cell; ++i)
+        {
+            boundary_term_viscous[i] *=-1.0; // negate as we are moving the term to the right hand side.
+        }
+    }
+    else
+    {
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q;
+        for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
+            // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
+            // The way it is stored in metric_operators is to use sum-factorization in each direction,
+            // but here it is cleaner to apply a reference transformation in each Tensor block returned by physics.
+            dealii::Tensor<2,dim,adtype> metric_cofactor_vol;
+            for(int idim=0; idim<dim; idim++){
+                for(int jdim=0; jdim<dim; jdim++){
+                    metric_cofactor_vol[idim][jdim] = metric_oper.metric_cofactor_vol[idim][jdim][iquad];
+                }
+            }
+            std::array<adtype,nstate> soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+            std::array<adtype,nstate> filtered_soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
+            for(int istate=0; istate<nstate; istate++){
+                soln_state[istate] = soln_at_vol_q[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_vol_q[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state[istate][idim] = aux_soln_at_vol_q[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_vol_q[istate][idim][iquad];
+                }
+            }
+        
+        // Compute the physical dissipative flux
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
+        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
+        for(int istate=0; istate<nstate; istate++){
+            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
+            // transform the dissipative flux to reference space
+            metric_oper.transform_physical_to_reference(
+                diffusive_phys_flux[istate],
+                metric_cofactor_vol,
+                diffusive_ref_flux);
+            for(int idim=0; idim<dim; idim++){
+                //allocate
+                if(iquad == 0){
+                    diffusive_ref_flux_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+                }
+                //write data
+                diffusive_ref_flux_at_vol_q[istate][idim][iquad] = diffusive_ref_flux[idim];
+            }
+        }
+
+        } // quad loop ends
+    const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
+    const int dim_not_zero = iface / 2;//reference direction of face integer division
+    
+    std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
+    
+    for(int istate=0; istate<nstate; istate++){
+        //allocate
+        diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
+        
+        //interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
+        flux_basis.matrix_vector_mult_surface_1D(face_orientation, 
+                                                 iface,
+                                                 diffusive_ref_flux_at_vol_q[istate][dim_not_zero],
+                                                 diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
+                                                 flux_basis.oneD_surf_operator,
+                                                 flux_basis.oneD_vol_operator,
+                                                 false, unit_ref_normal_int[dim_not_zero]);
+    }
+    
+    std::array<std::vector<adtype>,nstate> diss_flux_dot_normal_diff;
+    for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
+        
+        dealii::Point<dim,adtype> surf_flux_node;
+        for(int idim=0; idim<dim; idim++){
+            surf_flux_node[idim] = metric_oper.flux_nodes_surf[iface][idim][iquad];
+        }
+        
+        // Dissipative numerical flux
+        pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
+        std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
+        if(this->using_wall_model && (boundary_id == 1001)) {
+            diss_auxi_num_flux_dot_n_at_q = pde_physics.dissipative_flux_dot_normal(
+                opposite_surf_soln_state, aux_soln_state, 
+                filtered_soln_state, filtered_aux_soln_state,
+                true, // on_boundary == true
+                current_cell_index, 
+                unit_phys_normal_int,
+                boundary_id);
+        } else {
+            diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
+                current_cell_index, current_cell_index,
+                0.0, 0.0,
+                soln_interp_to_face, soln_boundary,
+                aux_soln_state, grad_soln_boundary,
+                filtered_soln_state, soln_boundary,
+                filtered_aux_soln_state, grad_soln_boundary,
+                unit_phys_normal_int, penalty, true, boundary_id);
+        }
+        for(int istate=0; istate<nstate; istate++){
+            // allocate
+            if(iquad==0){
+                diss_flux_dot_normal_diff[istate].resize(n_face_quad_pts);
+            }
+            // write data
+            diss_flux_dot_normal_diff[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate]
+                                                     - diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate][iquad];
+        }
+    } //quad 
+        
+    }// else
+}
+
+
     
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -2158,9 +2158,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         for(int idim=0; idim<dim; idim++){
             surf_flux_node[idim] = metric_oper.flux_nodes_surf[iface][idim][iquad];
         }
-        //I am not sure if BC should be from solution interpolated to face
-        //or solution from the projected entropy variables.
-        //Now, it uses projected entropy variables for NSFR, and solution
+        
+        //The BC uses projected entropy variables for NSFR, and solution
         //interpolated to face for conservative DG.
         pde_physics.boundary_face_values (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
         
@@ -2172,12 +2171,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
             // allocate
             if(iquad==0){
                 conv_flux_dot_normal[istate].resize(n_face_quad_pts);
-                diss_flux_dot_normal_diff[istate].resize(n_face_quad_pts);
             }
             // write data
             conv_flux_dot_normal[istate][iquad] = face_Jac_norm_scaled * conv_num_flux_dot_n_at_q[istate];
-            diss_flux_dot_normal_diff[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate]
-                                                     - diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate][iquad];
         }
     }
 
@@ -2213,14 +2209,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         soln_basis.inner_product_surface_1D(face_orientation, 
                                             iface,
                                             conv_flux_dot_normal[istate], 
-                                            face_quad_weights, rhs, 
-                                            soln_basis.oneD_surf_operator, 
-                                            soln_basis.oneD_vol_operator,
-                                            true, -1.0);//adding=true, scaled by factor=-1.0 bc subtract it
-        //Dissipative surface numerical flux.
-        soln_basis.inner_product_surface_1D(face_orientation, 
-                                            iface,
-                                            diss_flux_dot_normal_diff[istate], 
                                             face_quad_weights, rhs, 
                                             soln_basis.oneD_surf_operator, 
                                             soln_basis.oneD_vol_operator,
@@ -2295,91 +2283,135 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
                 }
             }
         
-        // Compute the physical dissipative flux
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
-        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
-        for(int istate=0; istate<nstate; istate++){
-            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
-            // transform the dissipative flux to reference space
-            metric_oper.transform_physical_to_reference(
-                diffusive_phys_flux[istate],
-                metric_cofactor_vol,
-                diffusive_ref_flux);
-            for(int idim=0; idim<dim; idim++){
-                //allocate
-                if(iquad == 0){
-                    diffusive_ref_flux_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+            // Compute the physical dissipative flux
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
+            diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
+            for(int istate=0; istate<nstate; istate++){
+                dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
+                // transform the dissipative flux to reference space
+                metric_oper.transform_physical_to_reference(
+                    diffusive_phys_flux[istate],
+                    metric_cofactor_vol,
+                    diffusive_ref_flux);
+                for(int idim=0; idim<dim; idim++){
+                    //allocate
+                    if(iquad == 0){
+                        diffusive_ref_flux_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+                    }
+                    //write data
+                    diffusive_ref_flux_at_vol_q[istate][idim][iquad] = diffusive_ref_flux[idim];
                 }
-                //write data
-                diffusive_ref_flux_at_vol_q[istate][idim][iquad] = diffusive_ref_flux[idim];
             }
-        }
 
         } // quad loop ends
-    const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
-    const int dim_not_zero = iface / 2;//reference direction of face integer division
-    
-    std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
-    
-    for(int istate=0; istate<nstate; istate++){
-        //allocate
-        diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
+        const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
+        const int dim_not_zero = iface / 2;//reference direction of face integer division
         
-        //interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
-        flux_basis.matrix_vector_mult_surface_1D(face_orientation, 
-                                                 iface,
-                                                 diffusive_ref_flux_at_vol_q[istate][dim_not_zero],
-                                                 diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
-                                                 flux_basis.oneD_surf_operator,
-                                                 flux_basis.oneD_vol_operator,
-                                                 false, unit_ref_normal_int[dim_not_zero]);
-    }
-    
-    std::array<std::vector<adtype>,nstate> diss_flux_dot_normal_diff;
-    for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
+        std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
         
-        dealii::Point<dim,adtype> surf_flux_node;
-        for(int idim=0; idim<dim; idim++){
-            surf_flux_node[idim] = metric_oper.flux_nodes_surf[iface][idim][iquad];
-        }
-        
-        // Dissipative numerical flux
-        pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
-        std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
-        if(this->using_wall_model && (boundary_id == 1001)) {
-            diss_auxi_num_flux_dot_n_at_q = pde_physics.dissipative_flux_dot_normal(
-                opposite_surf_soln_state, aux_soln_state, 
-                filtered_soln_state, filtered_aux_soln_state,
-                true, // on_boundary == true
-                current_cell_index, 
-                unit_phys_normal_int,
-                boundary_id);
-        } else {
-            diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
-                current_cell_index, current_cell_index,
-                0.0, 0.0,
-                soln_interp_to_face, soln_boundary,
-                aux_soln_state, grad_soln_boundary,
-                filtered_soln_state, soln_boundary,
-                filtered_aux_soln_state, grad_soln_boundary,
-                unit_phys_normal_int, penalty, true, boundary_id);
-        }
         for(int istate=0; istate<nstate; istate++){
-            // allocate
-            if(iquad==0){
-                diss_flux_dot_normal_diff[istate].resize(n_face_quad_pts);
-            }
-            // write data
-            diss_flux_dot_normal_diff[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate]
-                                                     - diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate][iquad];
+            //allocate
+            diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
+            
+            //interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
+            flux_basis.matrix_vector_mult_surface_1D(face_orientation, 
+                                                     iface,
+                                                     diffusive_ref_flux_at_vol_q[istate][dim_not_zero],
+                                                     diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
+                                                     flux_basis.oneD_surf_operator,
+                                                     flux_basis.oneD_vol_operator,
+                                                     false, unit_ref_normal_int[dim_not_zero]);
         }
-    } //quad 
         
-    }// else
+        std::array<std::vector<adtype>,nstate> diss_flux_dot_normal_diff;
+        for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
+            
+            //get the projected entropy variables, soln, and 
+            //auxiliary solution on the surface point.
+            std::array<adtype,nstate> entropy_var_face;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+            std::array<adtype,nstate> soln_interp_to_face;
+            std::array<adtype,nstate> soln_state;
+            std::array<adtype,nstate> opposite_surf_soln_state;
+            std::array<adtype,nstate> filtered_soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
+            for(int istate=0; istate<nstate; istate++){
+                soln_interp_to_face[istate] = soln_at_surf_q[istate][iquad];
+                soln_state[istate] = soln_interp_to_face[istate]; // initialize as solution interpolated to face
+                entropy_var_face[istate] = projected_entropy_var_surf[istate][iquad];
+                if(this->using_wall_model && (boundary_id == 1001)) opposite_surf_soln_state[istate] = soln_at_opposite_surf_q[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_surf_q[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state[istate][idim] = aux_soln_at_surf_q[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_surf_q[istate][idim][iquad];
+                }
+            }
+
+            //extract solution on surface from projected entropy variables if NSFR; conservative DG uses solution interpolated to face (i.e. the initialization)
+            if((this->all_parameters->use_split_form || this->all_parameters->use_curvilinear_split_form) && this->use_projected_entropy_variables_for_nsfr_boundary_term) {
+                soln_state = pde_physics.compute_conservative_variables_from_entropy_variables (entropy_var_face);    
+            }
+
+            std::array<adtype,nstate> soln_boundary;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> grad_soln_boundary;
+            
+            dealii::Point<dim,adtype> surf_flux_node;
+            for(int idim=0; idim<dim; idim++){
+                surf_flux_node[idim] = metric_oper.flux_nodes_surf[iface][idim][iquad];
+            }
+            
+            // Dissipative numerical flux
+            pde_physics.boundary_face_values_viscous_flux (boundary_id, surf_flux_node, unit_phys_normal_int, soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, soln_boundary, grad_soln_boundary);
+            std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
+            if(this->using_wall_model && (boundary_id == 1001)) {
+                diss_auxi_num_flux_dot_n_at_q = pde_physics.dissipative_flux_dot_normal(
+                    opposite_surf_soln_state, aux_soln_state, 
+                    filtered_soln_state, filtered_aux_soln_state,
+                    true, // on_boundary == true
+                    current_cell_index, 
+                    unit_phys_normal_int,
+                    boundary_id);
+            } else {
+                diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
+                    current_cell_index, current_cell_index,
+                    0.0, 0.0,
+                    soln_interp_to_face, soln_boundary,
+                    aux_soln_state, grad_soln_boundary,
+                    filtered_soln_state, soln_boundary,
+                    filtered_aux_soln_state, grad_soln_boundary,
+                    unit_phys_normal_int, penalty, true, boundary_id);
+            }
+            for(int istate=0; istate<nstate; istate++){
+                // allocate
+                if(iquad==0){
+                    diss_flux_dot_normal_diff[istate].resize(n_face_quad_pts);
+                }
+                // write data
+                diss_flux_dot_normal_diff[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate]
+                                                         - diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate][iquad];
+            }
+        } //quad 
+        
+        //solve rhs
+        for(int istate=0; istate<nstate; istate++){
+            std::vector<adtype> rhs(n_shape_fns);
+            //Dissipative surface numerical flux.
+            soln_basis.inner_product_surface_1D(face_orientation, 
+                                                iface,
+                                                diss_flux_dot_normal_diff[istate], 
+                                                face_quad_weights, rhs, 
+                                                soln_basis.oneD_surf_operator, 
+                                                soln_basis.oneD_vol_operator,
+                                                false, -1.0);//scaled by factor=-1.0 bc subtract it
+
+            for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                boundary_term_viscous[istate*n_shape_fns + ishape] = rhs[ishape];
+            }
+        }
+        
+    }
 }
-
-
-    
+ 
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volume_and_face(
@@ -2760,7 +2792,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
 
     // First we do interior.
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> conv_ref_flux_at_vol_q_int;
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q_int;
     for (unsigned int iquad=0; iquad<n_quad_pts_vol_int; ++iquad) {
         // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
         // The way it is stored in metric_operators is to use sum-factorization in each direction,
@@ -2791,14 +2822,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             conv_phys_flux = pde_physics.convective_flux (soln_state);
         }
 
-        // Compute the physical dissipative flux
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
-        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
-
         // Write the values in a way that we can use sum-factorization on.
         for(int istate=0; istate<nstate; istate++){
             dealii::Tensor<1,dim,adtype> conv_ref_flux;
-            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
             // transform the conservative convective physical flux to reference space
             if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                 metric_oper_int.transform_physical_to_reference(
@@ -2806,11 +2832,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                     metric_cofactor_vol_int,
                     conv_ref_flux);
             }
-            // transform the dissipative flux to reference space
-            metric_oper_int.transform_physical_to_reference(
-                diffusive_phys_flux[istate],
-                metric_cofactor_vol_int,
-                diffusive_ref_flux);
 
             // Write the data in a way that we can use sum-factorization on.
             // Since sum-factorization improves the speed for matrix-vector multiplications,
@@ -2819,13 +2840,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                 // allocate
                 if(iquad == 0){
                     conv_ref_flux_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
-                    diffusive_ref_flux_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
                 }
                 // write data
                 if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                     conv_ref_flux_at_vol_q_int[istate][idim][iquad] = conv_ref_flux[idim];
                 }
-                diffusive_ref_flux_at_vol_q_int[istate][idim][iquad] = diffusive_ref_flux[idim];
             }
         }
     }
@@ -2833,7 +2852,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     // Next we do exterior volume reference fluxes.
     // Note we split the quad integrals because the interior and exterior could be of different poly basis
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> conv_ref_flux_at_vol_q_ext;
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q_ext;
     for (unsigned int iquad=0; iquad<n_quad_pts_vol_ext; ++iquad) {
 
         // Extract exterior volume metric cofactor matrix at given volume cubature node.
@@ -2863,14 +2881,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             conv_phys_flux = pde_physics.convective_flux (soln_state);
         }
 
-        // Compute the physical dissipative flux
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
-        diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, neighbor_cell_index);
-
         // Write the values in a way that we can use sum-factorization on.
         for(int istate=0; istate<nstate; istate++){
             dealii::Tensor<1,dim,adtype> conv_ref_flux;
-            dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
             // transform the conservative convective physical flux to reference space
             if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                 metric_oper_ext.transform_physical_to_reference(
@@ -2878,11 +2891,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                     metric_cofactor_vol_ext,
                     conv_ref_flux);
             }
-            // transform the dissipative flux to reference space
-            metric_oper_ext.transform_physical_to_reference(
-                diffusive_phys_flux[istate],
-                metric_cofactor_vol_ext,
-                diffusive_ref_flux);
 
             // Write the data in a way that we can use sum-factorization on.
             // Since sum-factorization improves the speed for matrix-vector multiplications,
@@ -2891,13 +2899,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                 // allocate
                 if(iquad == 0){
                     conv_ref_flux_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
-                    diffusive_ref_flux_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
                 }
                 // write data
                 if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
                     conv_ref_flux_at_vol_q_ext[istate][idim][iquad] = conv_ref_flux[idim];
                 }
-                diffusive_ref_flux_at_vol_q_ext[istate][idim][iquad] = diffusive_ref_flux[idim];
             }
         }
     }
@@ -2915,14 +2921,10 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
 
     std::array<std::vector<adtype>,nstate> conv_int_vol_ref_flux_interp_to_face_dot_ref_normal;
     std::array<std::vector<adtype>,nstate> conv_ext_vol_ref_flux_interp_to_face_dot_ref_normal;
-    std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
-    std::array<std::vector<adtype>,nstate> diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal;
     for(int istate=0; istate<nstate; istate++){
         //allocate
         conv_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
         conv_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
-        diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
-        diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
 
         // solve
         // Note, since the normal is zero in all other reference directions, we only have to interpolate one given reference direction to the facet
@@ -2945,21 +2947,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                                                          false, unit_ref_normal_ext[dim_not_zero_ext]);//don't add to previous value, unit_normal ext is -unit normal int
         }
 
-        // interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
-        flux_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, 
-                                                     iface,
-                                                     diffusive_ref_flux_at_vol_q_int[istate][dim_not_zero_int],
-                                                     diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
-                                                     flux_basis_int.oneD_surf_operator,
-                                                     flux_basis_int.oneD_vol_operator,
-                                                     false, unit_ref_normal_int[dim_not_zero_int]);
-        flux_basis_ext.matrix_vector_mult_surface_1D(face_orientation_ext, 
-                                                     neighbor_iface,
-                                                     diffusive_ref_flux_at_vol_q_ext[istate][dim_not_zero_ext],
-                                                     diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
-                                                     flux_basis_ext.oneD_surf_operator,
-                                                     flux_basis_ext.oneD_vol_operator,
-                                                     false, unit_ref_normal_ext[dim_not_zero_ext]);
     }
 
 
@@ -3276,7 +3263,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     // Evaluate reference numerical fluxes.
     
     std::array<std::vector<adtype>,nstate> conv_num_flux_dot_n;
-    std::array<std::vector<adtype>,nstate> diss_auxi_num_flux_dot_n;
     for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
         // Copy Metric Cofactor on the facet in a way can use for transforming Tensor Blocks to reference space
         // The way it is stored in metric_operators is to use sum-factorization in each direction,
@@ -3292,27 +3278,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
 
         std::array<adtype,nstate> entropy_var_face_int;
         std::array<adtype,nstate> entropy_var_face_ext;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state_int;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state_ext;
-        std::array<adtype,nstate> soln_interp_to_face_int;
-        std::array<adtype,nstate> soln_interp_to_face_ext;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state_int;
-        std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state_ext;
-        std::array<adtype,nstate> filtered_soln_interp_to_face_int;
-        std::array<adtype,nstate> filtered_soln_interp_to_face_ext;
         for(int istate=0; istate<nstate; istate++){
-            soln_interp_to_face_int[istate] = soln_at_surf_q_int[istate][iquad];
-            soln_interp_to_face_ext[istate] = soln_at_surf_q_ext[istate][iquad];
-            if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_int[istate] = legendre_soln_at_surf_q_int[istate][iquad];
-            if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_ext[istate] = legendre_soln_at_surf_q_ext[istate][iquad];
             entropy_var_face_int[istate] = projected_entropy_var_surf_int_corrected[istate][iquad];
             entropy_var_face_ext[istate] = projected_entropy_var_surf_ext_corrected[istate][iquad];
-            for(int idim=0; idim<dim; idim++){
-                aux_soln_state_int[istate][idim] = aux_soln_at_surf_q_int[istate][idim][iquad];
-                aux_soln_state_ext[istate][idim] = aux_soln_at_surf_q_ext[istate][idim][iquad];
-                if(this->do_compute_filtered_solution) filtered_aux_soln_state_int[istate][idim] = legendre_aux_soln_at_surf_q_int[istate][idim][iquad];
-                if(this->do_compute_filtered_solution) filtered_aux_soln_state_ext[istate][idim] = legendre_aux_soln_at_surf_q_ext[istate][idim][iquad];
-            }
         }
 
         std::array<adtype,nstate> soln_state_int;
@@ -3342,18 +3310,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
         // Note that the facet determinant of metric jacobian is the above norm multiplied by the determinant of the metric Jacobian evaluated on the facet.
         // Since the determinant of the metric Jacobian evaluated on the face cancels off, we can just scale the numerical flux by the norm.
         std::array<adtype,nstate> conv_num_flux_dot_n_at_q;
-        std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
         // Convective numerical flux. 
         conv_num_flux_dot_n_at_q = conv_num_flux.evaluate_flux(soln_state_int, soln_state_ext, unit_phys_normal_int);
-        // dissipative numerical flux
-        diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
-            current_cell_index, neighbor_cell_index,
-            0.0, 0.0,
-            soln_interp_to_face_int, soln_interp_to_face_ext,
-            aux_soln_state_int, aux_soln_state_ext,
-            filtered_soln_interp_to_face_int, filtered_soln_interp_to_face_ext,
-            filtered_aux_soln_state_int, filtered_aux_soln_state_ext,
-            unit_phys_normal_int, penalty, false);
 
         // Write the values in a way that we can use sum-factorization on.
         for(int istate=0; istate<nstate; istate++){
@@ -3364,12 +3322,10 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             // allocate
             if(iquad == 0){
                 conv_num_flux_dot_n[istate].resize(n_face_quad_pts);
-                diss_auxi_num_flux_dot_n[istate].resize(n_face_quad_pts);
             }
 
             // write data
             conv_num_flux_dot_n[istate][iquad] = face_Jac_norm_scaled * conv_num_flux_dot_n_at_q[istate];
-            diss_auxi_num_flux_dot_n[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate];
         }
     }
 
@@ -3405,15 +3361,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                                                     soln_basis_int.oneD_vol_operator,
                                                     false, 1.0);
         }
-        // dissipative flux
-        soln_basis_int.inner_product_surface_1D(face_orientation_int, 
-                                                iface,
-                                                diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
-                                                surf_quad_weights, rhs_int, 
-                                                soln_basis_int.oneD_surf_operator, 
-                                                soln_basis_int.oneD_vol_operator,
-                                                true, 1.0);//adding=true, subtract the negative so add it
-        // convective numerical flux
         soln_basis_int.inner_product_surface_1D(face_orientation_int, 
                                                 iface,
                                                 conv_num_flux_dot_n[istate], 
@@ -3421,15 +3368,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                                                 soln_basis_int.oneD_surf_operator, 
                                                 soln_basis_int.oneD_vol_operator,
                                                 true, -1.0);//adding=true, scaled by factor=-1.0 bc subtract it
-        // dissipative numerical flux
-        soln_basis_int.inner_product_surface_1D(face_orientation_int, 
-                                                iface,
-                                                diss_auxi_num_flux_dot_n[istate], 
-                                                surf_quad_weights, rhs_int, 
-                                                soln_basis_int.oneD_surf_operator, 
-                                                soln_basis_int.oneD_vol_operator,
-                                                true, -1.0);//adding=true, scaled by factor=-1.0 bc subtract it
-
 
         for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
             local_rhs_int_cell[istate*n_shape_fns_int + ishape] += rhs_int[ishape];
@@ -3465,15 +3403,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                                                     soln_basis_ext.oneD_vol_operator,
                                                     false, 1.0);//adding false
         }
-        // dissipative flux
-        soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
-                                                neighbor_iface,
-                                                diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
-                                                surf_quad_weights, rhs_ext, 
-                                                soln_basis_ext.oneD_surf_operator, 
-                                                soln_basis_ext.oneD_vol_operator,
-                                                true, 1.0);//adding=true
-        // convective numerical flux
         soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
                                                 neighbor_iface,
                                                 conv_num_flux_dot_n[istate], 
@@ -3481,20 +3410,311 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
                                                 soln_basis_ext.oneD_surf_operator, 
                                                 soln_basis_ext.oneD_vol_operator,
                                                 true, 1.0);//adding=true, scaled by factor=1.0 because negative numerical flux and subtract it
-        // dissipative numerical flux
-        soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
-                                                neighbor_iface,
-                                                diss_auxi_num_flux_dot_n[istate], 
-                                                surf_quad_weights, rhs_ext, 
-                                                soln_basis_ext.oneD_surf_operator, 
-                                                soln_basis_ext.oneD_vol_operator,
-                                                true, 1.0);//adding=true, scaled by factor=1.0 because negative numerical flux and subtract it
-
 
         for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
             local_rhs_ext_cell[istate*n_shape_fns_ext + ishape] += rhs_ext[ishape];
         }
     }
+}
+
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_primal(
+    const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+    const unsigned int                            poly_degree,
+    OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+    OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+    dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS)
+{
+    face_term_int.resize(n_dofs_cell_int);
+    face_term_ext.resize(n_dofs_cell_ext);
+    if(this->all_parameters->use_viscous_br2_entropystable)
+    {
+        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_face_term_entropystable_br2(
+         face_orientation_int,
+         face_orientation_ext,
+         iface_int,
+         iface_ext,
+         entropy_var_coeff_int,
+         entropy_var_coeff_ext,
+         entropy_var_at_vol_int,
+         entropy_var_at_vol_ext,
+         entropy_var_at_surf_int,
+         entropy_var_at_surf_ext,
+         unit_phys_normal_int,
+         JxW_face,
+         poly_degree_int,
+         poly_degree_ext,
+         n_vol_quad_pts_int,
+         n_vol_quad_pts_ext,
+         n_dofs_cell_int,
+         n_dofs_cell_ext,
+         n_face_quad_pts,
+         soln_basis_int,
+         soln_basis_ext,
+         flux_basis_int,
+         flux_basis_ext,
+         metric_oper_int,
+         metric_oper_ext,
+         pde_physics,
+         face_term_int,
+         face_term_ext);
+
+         for(unsigned int i=0; i<n_dofs_cell_int; ++i)
+         {
+            face_term_int[i]*=-1.0;
+         }
+         for(unsigned int i=0; i<n_dofs_cell_ext; ++i)
+         {
+            face_term_ext[i]*=-1.0;
+         }
+    }
+    else
+    {
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q_int;
+        for (unsigned int iquad=0; iquad<n_quad_pts_vol_int; ++iquad) {
+            // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
+            // The way it is stored in metric_operators is to use sum-factorization in each direction,
+            // but here it is cleaner to apply a reference transformation in each Tensor block returned by physics.
+            dealii::Tensor<2,dim,adtype> metric_cofactor_vol_int;
+            for(int idim=0; idim<dim; idim++){
+                for(int jdim=0; jdim<dim; jdim++){
+                    metric_cofactor_vol_int[idim][jdim] = metric_oper_int.metric_cofactor_vol[idim][jdim][iquad];
+                }
+            }
+            std::array<adtype,nstate> soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+            std::array<adtype,nstate> filtered_soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
+            for(int istate=0; istate<nstate; istate++){
+                soln_state[istate] = soln_at_vol_q_int[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_vol_q_int[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state[istate][idim] = aux_soln_at_vol_q_int[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_vol_q_int[istate][idim][iquad];
+                }
+            }
+            
+            // Compute the physical dissipative flux
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
+            diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, current_cell_index);
+            for(int istate=0; istate<nstate; istate++){
+                dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
+                // transform the dissipative flux to reference space
+                metric_oper_int.transform_physical_to_reference(
+                    diffusive_phys_flux[istate],
+                    metric_cofactor_vol_int,
+                    diffusive_ref_flux);
+                
+                for(int idim=0; idim<dim; idim++){
+                    // allocate
+                    if(iquad == 0){
+                        diffusive_ref_flux_at_vol_q_int[istate][idim].resize(n_quad_pts_vol_int);
+                    }
+                    diffusive_ref_flux_at_vol_q_int[istate][idim][iquad] = diffusive_ref_flux[idim];
+                }
+            }
+        } // iquad_vol_int ends
+        
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q_ext;
+        for (unsigned int iquad=0; iquad<n_quad_pts_vol_ext; ++iquad) {
+
+            // Extract exterior volume metric cofactor matrix at given volume cubature node.
+            dealii::Tensor<2,dim,adtype> metric_cofactor_vol_ext;
+            for(int idim=0; idim<dim; idim++){
+                for(int jdim=0; jdim<dim; jdim++){
+                    metric_cofactor_vol_ext[idim][jdim] = metric_oper_ext.metric_cofactor_vol[idim][jdim][iquad];
+                }
+            }
+
+            std::array<adtype,nstate> soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+            std::array<adtype,nstate> filtered_soln_state;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state;
+            for(int istate=0; istate<nstate; istate++){
+                soln_state[istate] = soln_at_vol_q_ext[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_state[istate] = legendre_soln_at_vol_q_ext[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state[istate][idim] = aux_soln_at_vol_q_ext[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state[istate][idim] = legendre_aux_soln_at_vol_q_ext[istate][idim][iquad];
+                }
+            }
+
+            // Compute the physical dissipative flux
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> diffusive_phys_flux;
+            diffusive_phys_flux = pde_physics.dissipative_flux(soln_state, aux_soln_state, filtered_soln_state, filtered_aux_soln_state, neighbor_cell_index);
+
+            // Write the values in a way that we can use sum-factorization on.
+            for(int istate=0; istate<nstate; istate++){
+                dealii::Tensor<1,dim,adtype> diffusive_ref_flux;
+                // transform the dissipative flux to reference space
+                metric_oper_ext.transform_physical_to_reference(
+                    diffusive_phys_flux[istate],
+                    metric_cofactor_vol_ext,
+                    diffusive_ref_flux);
+
+                for(int idim=0; idim<dim; idim++){
+                    // allocate
+                    if(iquad == 0){
+                        diffusive_ref_flux_at_vol_q_ext[istate][idim].resize(n_quad_pts_vol_ext);
+                    }
+                    diffusive_ref_flux_at_vol_q_ext[istate][idim][iquad] = diffusive_ref_flux[idim];
+                }
+            }
+        } // iquad vol ext ends
+        
+        const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
+        const dealii::Tensor<1,dim,double> unit_ref_normal_ext = dealii::GeometryInfo<dim>::unit_normal_vector[neighbor_iface];
+        // Extract the reference direction that is outward facing on the facet.
+        const int dim_not_zero_int = iface / 2;//reference direction of face integer division
+        const int dim_not_zero_ext = neighbor_iface / 2;//reference direction of face integer division
+        
+        std::array<std::vector<adtype>,nstate> diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal;
+        std::array<std::vector<adtype>,nstate> diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal;
+        for(int istate=0; istate<nstate; istate++){
+            //allocate
+            diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
+            diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate].resize(n_face_quad_pts);
+
+            // solve
+            // Note, since the normal is zero in all other reference directions, we only have to interpolate one given reference direction to the facet
+            
+            // interpolate reference volume dissipative flux to the facet, and apply unit reference normal as scaled by 1.0 or -1.0
+            flux_basis_int.matrix_vector_mult_surface_1D(face_orientation_int, 
+                                                         iface,
+                                                         diffusive_ref_flux_at_vol_q_int[istate][dim_not_zero_int],
+                                                         diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
+                                                         flux_basis_int.oneD_surf_operator,
+                                                         flux_basis_int.oneD_vol_operator,
+                                                         false, unit_ref_normal_int[dim_not_zero_int]);
+            flux_basis_ext.matrix_vector_mult_surface_1D(face_orientation_ext, 
+                                                         neighbor_iface,
+                                                         diffusive_ref_flux_at_vol_q_ext[istate][dim_not_zero_ext],
+                                                         diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate],
+                                                         flux_basis_ext.oneD_surf_operator,
+                                                         flux_basis_ext.oneD_vol_operator,
+                                                         false, unit_ref_normal_ext[dim_not_zero_ext]);
+        }
+        
+        std::array<std::vector<adtype>,nstate> diss_auxi_num_flux_dot_n;
+        for (unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad) {
+
+            std::array<adtype,nstate> entropy_var_face_int;
+            std::array<adtype,nstate> entropy_var_face_ext;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state_int;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state_ext;
+            std::array<adtype,nstate> soln_interp_to_face_int;
+            std::array<adtype,nstate> soln_interp_to_face_ext;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state_int;
+            std::array<dealii::Tensor<1,dim,adtype>,nstate> filtered_aux_soln_state_ext;
+            std::array<adtype,nstate> filtered_soln_interp_to_face_int;
+            std::array<adtype,nstate> filtered_soln_interp_to_face_ext;
+            for(int istate=0; istate<nstate; istate++){
+                soln_interp_to_face_int[istate] = soln_at_surf_q_int[istate][iquad];
+                soln_interp_to_face_ext[istate] = soln_at_surf_q_ext[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_int[istate] = legendre_soln_at_surf_q_int[istate][iquad];
+                if(this->do_compute_filtered_solution) filtered_soln_interp_to_face_ext[istate] = legendre_soln_at_surf_q_ext[istate][iquad];
+                entropy_var_face_int[istate] = projected_entropy_var_surf_int_corrected[istate][iquad];
+                entropy_var_face_ext[istate] = projected_entropy_var_surf_ext_corrected[istate][iquad];
+                for(int idim=0; idim<dim; idim++){
+                    aux_soln_state_int[istate][idim] = aux_soln_at_surf_q_int[istate][idim][iquad];
+                    aux_soln_state_ext[istate][idim] = aux_soln_at_surf_q_ext[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state_int[istate][idim] = legendre_aux_soln_at_surf_q_int[istate][idim][iquad];
+                    if(this->do_compute_filtered_solution) filtered_aux_soln_state_ext[istate][idim] = legendre_aux_soln_at_surf_q_ext[istate][idim][iquad];
+                }
+            }
+
+            std::array<adtype,nstate> soln_state_int;
+            soln_state_int = pde_physics.compute_conservative_variables_from_entropy_variables (entropy_var_face_int);
+            std::array<adtype,nstate> soln_state_ext;
+            soln_state_ext = pde_physics.compute_conservative_variables_from_entropy_variables (entropy_var_face_ext);
+
+
+            if(!this->all_parameters->use_split_form && !this->all_parameters->use_curvilinear_split_form){
+                for(int istate=0; istate<nstate; istate++){
+                    soln_state_int[istate] = soln_at_surf_q_int[istate][iquad];
+                    soln_state_ext[istate] = soln_at_surf_q_ext[istate][iquad];
+                }
+            }
+
+            std::array<adtype,nstate> diss_auxi_num_flux_dot_n_at_q;
+            // dissipative numerical flux
+            diss_auxi_num_flux_dot_n_at_q = diss_num_flux.evaluate_auxiliary_flux(
+                current_cell_index, neighbor_cell_index,
+                0.0, 0.0,
+                soln_interp_to_face_int, soln_interp_to_face_ext,
+                aux_soln_state_int, aux_soln_state_ext,
+                filtered_soln_interp_to_face_int, filtered_soln_interp_to_face_ext,
+                filtered_aux_soln_state_int, filtered_aux_soln_state_ext,
+                unit_phys_normal_int, penalty, false);
+
+            // Write the values in a way that we can use sum-factorization on.
+            for(int istate=0; istate<nstate; istate++){
+                // allocate
+                if(iquad == 0){
+                    diss_auxi_num_flux_dot_n[istate].resize(n_face_quad_pts);
+                }
+
+                // write data
+                diss_auxi_num_flux_dot_n[istate][iquad] = face_Jac_norm_scaled * diss_auxi_num_flux_dot_n_at_q[istate];
+            }
+        }
+        
+        for(int istate=0; istate<nstate; istate++){
+            // interior RHS
+            std::vector<adtype> rhs_int(n_shape_fns_int);
+
+            // dissipative flux
+            soln_basis_int.inner_product_surface_1D(face_orientation_int, 
+                                                    iface,
+                                                    diffusive_int_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
+                                                    surf_quad_weights, rhs_int, 
+                                                    soln_basis_int.oneD_surf_operator, 
+                                                    soln_basis_int.oneD_vol_operator,
+                                                    false, 1.0);//subtract the negative so add it
+            // dissipative numerical flux
+            soln_basis_int.inner_product_surface_1D(face_orientation_int, 
+                                                    iface,
+                                                    diss_auxi_num_flux_dot_n[istate], 
+                                                    surf_quad_weights, rhs_int, 
+                                                    soln_basis_int.oneD_surf_operator, 
+                                                    soln_basis_int.oneD_vol_operator,
+                                                    true, -1.0);//adding=true, scaled by factor=-1.0 bc subtract it
+
+
+            for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
+                face_term_int[istate*n_shape_fns_int + ishape] = rhs_int[ishape];
+            }
+
+            // exterior RHS
+            std::vector<adtype> rhs_ext(n_shape_fns_ext);
+
+            // dissipative flux
+            soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
+                                                    neighbor_iface,
+                                                    diffusive_ext_vol_ref_flux_interp_to_face_dot_ref_normal[istate], 
+                                                    surf_quad_weights, rhs_ext, 
+                                                    soln_basis_ext.oneD_surf_operator, 
+                                                    soln_basis_ext.oneD_vol_operator,
+                                                    false, 1.0);
+            // dissipative numerical flux
+            soln_basis_ext.inner_product_surface_1D(face_orientation_ext, 
+                                                    neighbor_iface,
+                                                    diss_auxi_num_flux_dot_n[istate], 
+                                                    surf_quad_weights, rhs_ext, 
+                                                    soln_basis_ext.oneD_surf_operator, 
+                                                    soln_basis_ext.oneD_vol_operator,
+                                                    true, 1.0);//adding=true, scaled by factor=1.0 because negative numerical flux and subtract it
+
+
+            for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
+                face_term_ext[istate*n_shape_fns_ext + ishape] = rhs_ext[ishape];
+            }
+        }
+
+    }// else 
+    
 }
 
 /*******************************************************
@@ -3864,8 +4084,6 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_face_
     std::vector<adtype>                                                &face_term_int,
     std::vector<adtype>                                                &face_term_ext) const
 {
-    face_term_int.resize(n_dofs_cell_int);
-    face_term_ext.resize(n_dofs_cell_ext);
     const std::vector<double> &vol_quad_weights_int = this->volume_quadrature_collection[poly_degree_int].get_weights();
     const std::vector<double> &vol_quad_weights_ext = this->volume_quadrature_collection[poly_degree_ext].get_weights();
     std::vector<adtype> JxW_vol_int(n_vol_quad_pts_int);

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1065,6 +1065,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         legendre_soln_at_q,
         legendre_aux_soln_at_q,
         n_quad_pts,
+        n_shape_fns,
         poly_degree,
         pde_physics,
         soln_at_q,
@@ -1164,8 +1165,12 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
         //extract soln and auxiliary soln at quad pt to be used in physics
         std::array<adtype,nstate> soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
         for(int istate=0; istate<nstate; istate++){
             soln_state[istate] = soln_at_q[istate][iquad];
+            for(int idim=0; idim<dim; idim++){
+                aux_soln_state[istate][idim] = aux_soln_at_q[istate][idim][iquad];
+            }
         }
 
         // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
@@ -1431,6 +1436,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     projected_entropy_var_at_q,
     n_quad_pts,
     n_dofs_cell,
+    n_shape_fns,
     pde_physics,
     viscous_rhs_vol);
 
@@ -1446,8 +1452,9 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volu
     std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
     const unsigned int n_quad_pts,
+    const unsigned int n_shape_fns,
     const unsigned int poly_degree,
-    const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+    const Physics::PhysicsBase<dim, nspecies, nstate, adtype> &pde_physics,
     const std::array<std::vector<adtype>,nstate> &soln_at_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q)
 {
@@ -1607,13 +1614,14 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
     const std::array<std::vector<adtype>,nstate>  &entropy_var_at_q,
     const unsigned int  n_quad_pts,
     const unsigned int  n_dofs_cell,
-    const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+    const unsigned int  n_shape_fns,
+    Physics::PhysicsBase<dim, nspecies, nstate, adtype> &pde_physics,
     std::vector<adtype>     &vol_term_viscous) const
 {
-    vol_term_viscous.reinit(n_dofs_cell);   
+    vol_term_viscous.resize(n_dofs_cell);   
     if(this->all_parameters->use_viscous_br2_entropystable)
     {
-        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_volume_term_entropystable_br2(
+        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_entropystable_br2(
         poly_degree,
         entropy_var_coeff,
         entropy_var_at_q,
@@ -1622,6 +1630,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
         soln_basis,
         metric_oper,
         pde_physics,
+        this->volume_quadrature_collection[poly_degree].get_weights(),
         vol_term_viscous);
         for(unsigned int i=0; i<n_dofs_cell; ++i)
         {
@@ -1845,6 +1854,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     if(this->do_compute_filtered_solution) {
         // NOTE: This only pertains to advanced SGS models for LES
         compute_filtered_solution_volume_and_face(
+        face_orientation,
+        iface,
         legendre_soln_at_vol_q,
         legendre_aux_soln_at_vol_q,
         legendre_soln_at_surf_q,
@@ -2253,6 +2264,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         iface,
         boundary_id,
         poly_degree,
+        penalty,
         entropy_var_coeffs,
         projected_entropy_var_vol,
         projected_entropy_var_surf,
@@ -2260,12 +2272,12 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
         aux_soln_at_vol_q,
         soln_at_surf_q,
         aux_soln_at_surf_q,
-        soln_at_opposite_surf_q.
+        soln_at_opposite_surf_q,
         legendre_soln_at_vol_q,
         legendre_aux_soln_at_vol_q,
         legendre_soln_at_surf_q,
         legendre_aux_soln_at_surf_q,
-        n_vol_quad_pts,  
+        n_quad_pts_vol,  
         n_face_quad_pts,  
         n_dofs, 
         soln_basis,
@@ -2291,6 +2303,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
     const unsigned int                                                 iface,
     const unsigned int                                                 boundary_id,
     const unsigned int                                                 poly_degree,
+    const real                                                         penalty,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
@@ -2298,12 +2311,12 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
     const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
-    const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q.
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q,
     const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
     const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q,
-    const unsigned int                                                 n_vol_quad_pts,  
+    const unsigned int                                                 n_quad_pts_vol,  
     const unsigned int                                                 n_face_quad_pts,  
     const unsigned int                                                 n_dofs_cell, 
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
@@ -2311,11 +2324,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
     const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normals,
     const std::vector<adtype>                                          &JxW_face,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
     const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
     std::vector<adtype>                                                &boundary_term_viscous) const
 {
-    boundary_term_viscous.reinit(n_dofs_cell);   
+    boundary_term_viscous.resize(n_dofs_cell);   
     
     if(this->all_parameters->use_viscous_br2_entropystable)
     {
@@ -2327,15 +2340,16 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
         entropy_var_coeff,
         entropy_var_at_vol_quads,
         entropy_var_at_surf_quads,
-        n_vol_quad_pts,
+        n_quad_pts_vol,
         n_face_quad_pts,
         n_dofs_cell,
         soln_basis,
         flux_basis,
         metric_oper,
-        unit_phys_normal,
+        unit_phys_normals,
         JxW_face,
         pde_physics,
+        this->volume_quadrature_collection[poly_degree].get_weights(),
         boundary_term_viscous);
         for(unsigned int i=0; i<n_dofs_cell; ++i)
         {
@@ -2503,6 +2517,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_viscous
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volume_and_face(
+    std::vector<bool>                                                  face_orientation,
+    const unsigned int                                                 iface,
     std::array<std::vector<adtype>,nstate> &legendre_soln_at_vol_q,
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
     std::array<std::vector<adtype>,nstate> &legendre_soln_at_surf_q,
@@ -2846,6 +2862,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
     if(this->do_compute_filtered_solution) {
         // NOTE: This only pertains to advanced SGS models for LES
         compute_filtered_solution_volume_and_face(
+            face_orientation_int,
+            iface,
             legendre_soln_at_vol_q_int,
             legendre_aux_soln_at_vol_q_int,
             legendre_soln_at_surf_q_int,
@@ -2860,6 +2878,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
             n_shape_fns_int,
             poly_degree_int);
         compute_filtered_solution_volume_and_face(
+            face_orientation_ext,
+            neighbor_iface,
             legendre_soln_at_vol_q_ext,
             legendre_aux_soln_at_vol_q_ext,
             legendre_soln_at_surf_q_ext,
@@ -3520,20 +3540,21 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
         face_orientation_ext,
         iface,
         neighbor_iface,
+        penalty,
         entropy_var_coeffs_int,
         entropy_var_coeffs_ext,
         projected_entropy_var_vol_int,
         projected_entropy_var_vol_ext,
         projected_entropy_var_surf_int_corrected,
         projected_entropy_var_surf_ext_corrected,
-        soln_at_vol_q_int.
+        soln_at_vol_q_int,
         soln_at_vol_q_ext,
         aux_soln_at_vol_q_int,
         aux_soln_at_vol_q_ext,
         soln_at_surf_q_int,
         soln_at_surf_q_ext,
         aux_soln_at_surf_q_int,
-        aux_soln_at_surf_q_ext;
+        aux_soln_at_surf_q_ext,
         legendre_soln_at_vol_q_int,
         legendre_aux_soln_at_vol_q_int,
         legendre_soln_at_vol_q_ext,
@@ -3551,6 +3572,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_strong(
         n_dofs_int,
         n_dofs_ext,
         n_face_quad_pts,
+        n_shape_fns_int,
+        n_shape_fns_ext,
         soln_basis_int,
         soln_basis_ext,
         flux_basis_int,
@@ -3581,20 +3604,21 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
     std::vector<bool>                                                  face_orientation_ext,
     const unsigned int                                                 iface_int,
     const unsigned int                                                 iface_ext,
+    const real                                                         penalty,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
-    const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int.
+    const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int,
     const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_ext,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_int,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_ext,
     const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_int,
     const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_ext,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_int,
-    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext;
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext,
     const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_int,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_int,
     const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_ext,
@@ -3612,13 +3636,15 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
     const unsigned int                                                  n_dofs_cell_int,
     const unsigned int                                                  n_dofs_cell_ext,
     const unsigned int                                                  n_face_quad_pts,
+    const unsigned int                                                  n_shape_fns_int,
+    const unsigned int                                                  n_shape_fns_ext,
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
     OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
     OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
     const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
     std::vector<adtype>                                                &viscous_face_term_int,
     std::vector<adtype>                                                &viscous_face_term_ext) const
@@ -3627,7 +3653,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
     viscous_face_term_ext.resize(n_dofs_cell_ext);
     if(this->all_parameters->use_viscous_br2_entropystable)
     {
-        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_face_term_entropystable_br2(
+        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_face_term_entropystable_br2(
          face_orientation_int,
          face_orientation_ext,
          iface_int,
@@ -3654,6 +3680,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
          metric_oper_int,
          metric_oper_ext,
          pde_physics,
+         this->volume_quadrature_collection[poly_degree_int].get_weights(),
+         this->volume_quadrature_collection[poly_degree_ext].get_weights(),
          viscous_face_term_int,
          viscous_face_term_ext);
 
@@ -3668,6 +3696,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
     }
     else
     {
+        const std::vector<double> &surf_quad_weights = this->face_quadrature_collection[poly_degree_int].get_weights();
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> diffusive_ref_flux_at_vol_q_int;
         for (unsigned int iquad=0; iquad<n_quad_pts_vol_int; ++iquad) {
             // Copy Metric Cofactor in a way can use for transforming Tensor Blocks to reference space
@@ -3760,8 +3789,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
             }
         } // iquad vol ext ends
         
-        const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface];
-        const dealii::Tensor<1,dim,double> unit_ref_normal_ext = dealii::GeometryInfo<dim>::unit_normal_vector[neighbor_iface];
+        const dealii::Tensor<1,dim,double> unit_ref_normal_int = dealii::GeometryInfo<dim>::unit_normal_vector[iface_int];
+        const dealii::Tensor<1,dim,double> unit_ref_normal_ext = dealii::GeometryInfo<dim>::unit_normal_vector[iface_ext];
         // Extract the reference direction that is outward facing on the facet.
         const int dim_not_zero_int = iface_int / 2;//reference direction of face integer division
         const int dim_not_zero_ext = iface_ext / 2;//reference direction of face integer division
@@ -3879,9 +3908,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                                                     soln_basis_int.oneD_vol_operator,
                                                     true, -1.0);//adding=true, scaled by factor=-1.0 bc subtract it
 
-
             for(unsigned int ishape=0; ishape<n_shape_fns_int; ishape++){
-                face_term_int[istate*n_shape_fns_int + ishape] = rhs_int[ishape];
+                viscous_face_term_int[istate*n_shape_fns_int + ishape] = rhs_int[ishape];
             }
 
             // exterior RHS
@@ -3904,9 +3932,8 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_face_term_viscous_pri
                                                     soln_basis_ext.oneD_vol_operator,
                                                     true, 1.0);//adding=true, scaled by factor=1.0 because negative numerical flux and subtract it
 
-
             for(unsigned int ishape=0; ishape<n_shape_fns_ext; ishape++){
-                face_term_ext[istate*n_shape_fns_ext + ishape] = rhs_ext[ishape];
+                viscous_face_term_ext[istate*n_shape_fns_ext + ishape] = rhs_ext[ishape];
             }
         }
 
@@ -3955,7 +3982,7 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::interpolate_to
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_vol,
     OPERATOR::basis_functions<dim,2*dim> &flux_basis,
     const unsigned int n_face_quad_pts,
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face) const
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face)
 {
     for(unsigned int s=0; s<nstate; ++s)
     {
@@ -3988,7 +4015,7 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::evaluate_face_
     const std::vector<adtype> &JxW_face,
     OPERATOR::basis_functions<dim,2*dim> &soln_basis,
     const unsigned int n_dofs_cell,
-    std::vector<adtype> &integral_val) const
+    std::vector<adtype> &integral_val)
 {
     integral_val.resize(n_dofs_cell); 
     const unsigned int n_shape_fns = n_dofs_cell/nstate;
@@ -4017,9 +4044,10 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_lift_p
     const std::vector<adtype> &JxW_face,
     const std::vector<adtype> &JxW_vol,
     OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+    const unsigned int /*n_face_quad_pts*/,
     const unsigned int n_vol_quad_pts,
     const bool is_interior_face,
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol) const
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol)
 {
     const unsigned int n_shape_fns_flux = n_vol_quad_pts; // collocated 
     for(unsigned int s=0; s<nstate; ++s)
@@ -4062,7 +4090,7 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_physic
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
     const unsigned int                                                 n_quad_pts,
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad) const
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad)
 {
     // Entropy grad wrt reference coordinates
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_ref_grad;
@@ -4093,9 +4121,9 @@ template <typename adtype>
 void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::apply_diffusion_matrix_entropy_based(
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
         const unsigned int                                                 n_quad_pts,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_in,
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out) const
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out)
 {
     //Resize
     for(unsigned int s=0; s<nstate; ++s)
@@ -4138,9 +4166,9 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_gradba
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
     const std::vector<double>                                          &weight_vect,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_input,
-    std::vector<adtype>                                                &integral_val) const
+    std::vector<adtype>                                                &integral_val)
 {
     const unsigned int n_shape_fns = n_dofs_cell / nstate; 
     
@@ -4217,17 +4245,17 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::compute_gradba
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
 void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_entropystable_br2(
-    const unsigned int                                                 poly_degree,
+    const unsigned int                                                 /*poly_degree*/,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_q,
     const unsigned int                                                  n_quad_pts,
     const unsigned int                                                  n_dofs_cell,
     OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
-    std::vector<adtype>                                                &vol_term) const
+    const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
+    const std::vector<double>                                          &weight_vect,
+    std::vector<adtype>                                                &vol_term)
 {
-    const std::vector<double> &weight_vect = this->volume_quadrature_collection[poly_degree].get_weights();
     // Entropy grad wrt physical coordinates
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_phys_grad;
     compute_physical_grad_entropy_var(
@@ -4264,8 +4292,8 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_face_
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
     const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal_int,
     const std::vector<adtype>                                          &JxW_face,
-    const unsigned int                                                  poly_degree_int,
-    const unsigned int                                                  poly_degree_ext,
+    const unsigned int                                                  /*poly_degree_int*/,
+    const unsigned int                                                  /*poly_degree_ext*/,
     const unsigned int                                                  n_vol_quad_pts_int,
     const unsigned int                                                  n_vol_quad_pts_ext,
     const unsigned int                                                  n_dofs_cell_int,
@@ -4277,12 +4305,12 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_face_
     OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
+    const std::vector<double>                                          &vol_quad_weights_int,
+    const std::vector<double>                                          &vol_quad_weights_ext,
     std::vector<adtype>                                                &face_term_int,
-    std::vector<adtype>                                                &face_term_ext) const
+    std::vector<adtype>                                                &face_term_ext)
 {
-    const std::vector<double> &vol_quad_weights_int = this->volume_quadrature_collection[poly_degree_int].get_weights();
-    const std::vector<double> &vol_quad_weights_ext = this->volume_quadrature_collection[poly_degree_ext].get_weights();
     std::vector<adtype> JxW_vol_int(n_vol_quad_pts_int);
     std::vector<adtype> JxW_vol_ext(n_vol_quad_pts_ext);
     for(unsigned int iquad=0; iquad<n_vol_quad_pts_int; ++iquad)
@@ -4508,7 +4536,7 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_bound
     std::vector<bool>                                                  face_orientation,
     const unsigned int                                                 iface,
     const unsigned int                                                 boundary_id,
-    const unsigned int                                                 poly_degree,
+    const unsigned int                                                 /*poly_degree*/,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
     const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
@@ -4520,10 +4548,10 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_bound
     OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
     const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal,
     const std::vector<adtype>                                          &JxW_face,
-    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
-    std::vector<adtype>                                                &boundary_term) const
+    const Physics::PhysicsBase<dim,nspecies,nstate,adtype>             &pde_physics,
+    const std::vector<double>                                          &vol_quad_weights,
+    std::vector<adtype>                                                &boundary_term)
 {
-    const std::vector<double> &vol_quad_weights = this->volume_quadrature_collection[poly_degree].get_weights();
     std::vector<adtype> JxW_vol(n_vol_quad_pts);
     for(unsigned int iquad=0; iquad<n_vol_quad_pts; ++iquad)
     {

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -511,7 +511,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_auxiliary_residual(co
         
         if(compute_dRdW || compute_dRdX || compute_d2R)
         {
-            pcout << "DG Strong's viscous terms cannot yet be automatically differentiated. Aborting..."<<std::endl;
+            pcout << "DG Strong's viscous terms cannot yet be automatically differentiated with Auxiliary Equation. Use strong form with entropy stable viscous DG instead. Aborting..."<<std::endl;
             std::abort();
         }
         //set auxiliary rhs to 0
@@ -649,7 +649,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_auxiliary_residual(co
         }
     }//end of if statement for diffusive
     else if (this->use_auxiliary_eq && (this->all_parameters->ode_solver_param.ode_solver_type == ODE_enum::implicit_solver)) {
-        pcout << "ERROR: " << "auxiliary currently only works for explicit time advancement. Aborting..." << std::endl;
+        pcout << "ERROR: " << "Implicit does not currently work for strong form with Auxiliary Equation. Use strong form with entropy stable viscous DG instead. Aborting..."<<std::endl;
         std::abort();
     } else {
         // Do nothing

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1038,7 +1038,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
 
 
     std::array<std::vector<adtype>,nstate> soln_at_q;
-    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> aux_soln_at_q; //auxiliary sol at flux nodes
     std::vector<std::array<double,nstate>> soln_at_q_for_max_CFL(n_quad_pts);//Need soln written in a different for to use pre-existing max CFL function
     // Interpolate each state to the quadrature points using sum-factorization
     // with the basis functions in each reference direction.
@@ -1046,11 +1045,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         soln_at_q[istate].resize(n_quad_pts);
         soln_basis.matrix_vector_mult_1D(soln_coeff[istate], soln_at_q[istate],
                                          soln_basis.oneD_vol_operator);
-        for(int idim=0; idim<dim; idim++){
-            aux_soln_at_q[istate][idim].resize(n_quad_pts);
-            soln_basis.matrix_vector_mult_1D(aux_soln_coeff[istate][idim], aux_soln_at_q[istate][idim],
-                                             soln_basis.oneD_vol_operator);
-        }
         for(unsigned int iquad=0; iquad<n_quad_pts; iquad++){
             soln_at_q_for_max_CFL[iquad][istate] = getValue<adtype>(soln_at_q[istate][iquad]);
         }
@@ -1575,6 +1569,55 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
             local_rhs_int_cell[istate*n_shape_fns + ishape] += rhs[ishape];
         }
 
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_primal(
+    const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_coeff,
+    const unsigned int                            poly_degree,
+    OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+    OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+    const std::array<std::vector<adtype>,nstate>  &entropy_var_coeff,
+    const std::array<std::vector<adtype>,nstate>  &entropy_var_at_q,
+    const unsigned int  n_quad_pts,
+    const unsigned int  n_dofs_cell,
+    const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+    std::vector<adtype>     &vol_term_viscous) const
+{
+    if(this->all_parameters->use_viscous_br2_entropystable)
+    {
+        vol_term_viscous.reinit(n_dofs_cell);   
+        EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>().assemble_volume_term_entropystable_br2(
+        poly_degree,
+        entropy_var_coeff,
+        entropy_var_at_q,
+        n_quad_pts,
+        n_dofs_cell,
+        soln_basis,
+        metric_oper,
+        pde_physics,
+        vol_term_viscous);
+        for(unsigned int i=0; i<n_dofs_cell; ++i)
+        {
+            vol_term_viscous[i] *=-1.0; // negate as we are moving the term to the right hand side.
+        }
+    }
+    else
+    {
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> aux_soln_at_q; //auxiliary sol at flux nodes
+        // Interpolate each state to the quadrature points using sum-factorization
+        // with the basis functions in each reference direction.
+        for(int istate=0; istate<nstate; istate++){
+            for(int idim=0; idim<dim; idim++){
+                aux_soln_at_q[istate][idim].resize(n_quad_pts);
+                soln_basis.matrix_vector_mult_1D(aux_soln_coeff[istate][idim], aux_soln_at_q[istate][idim],
+                                                 soln_basis.oneD_vol_operator);
+            }
+        }
     }
 }
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -3913,6 +3913,324 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_volum
         vol_term); 
 }
 
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_face_term_entropystable_br2(
+    std::vector<bool>                                                  face_orientation_int,
+    std::vector<bool>                                                  face_orientation_ext,
+    const unsigned int                                                 iface_int,
+    const unsigned int                                                 iface_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
+    const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal_int,
+    const std::vector<adtype>                                          &JxW_face,
+    const unsigned int                                                  poly_degree_int,
+    const unsigned int                                                  poly_degree_ext,
+    const unsigned int                                                  n_vol_quad_pts_int,
+    const unsigned int                                                  n_vol_quad_pts_ext,
+    const unsigned int                                                  n_dofs_cell_int,
+    const unsigned int                                                  n_dofs_cell_ext,
+    const unsigned int                                                  n_face_quad_pts,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    std::vector<adtype>                                                &face_term_int,
+    std::vector<adtype>                                                &face_term_ext) const
+{
+    face_term_int.resize(n_dofs_cell_int);
+    face_term_ext.resize(n_dofs_cell_ext);
+    const std::vector<double> &vol_quad_weights_int = this->volume_quadrature_collection[poly_degree_int].get_weights();
+    const std::vector<double> &vol_quad_weights_ext = this->volume_quadrature_collection[poly_degree_ext].get_weights();
+    std::vector<adtype> JxW_vol_int(n_vol_quad_pts_int);
+    std::vector<adtype> JxW_vol_ext(n_vol_quad_pts_ext);
+    for(unsigned int iquad=0; iquad<n_vol_quad_pts_int; ++iquad)
+    {
+        JxW_vol_int[iquad] = metric_oper_int.det_Jac_vol[iquad]*vol_quad_weights_int[iquad];
+    }
+    for(unsigned int iquad=0; iquad<n_vol_quad_pts_ext; ++iquad)
+    {
+        JxW_vol_ext[iquad] = metric_oper_ext.det_Jac_vol[iquad]*vol_quad_weights_ext[iquad];
+    }
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_phys_grad_int;
+    compute_physical_grad_entropy_var(
+       entropy_var_coeff_int,
+       soln_basis_int,
+       metric_oper_int,
+       n_vol_quad_pts_int,
+       entropy_var_phys_grad_int);
+    
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_phys_grad_ext;
+    compute_physical_grad_entropy_var(
+       entropy_var_coeff_ext,
+       soln_basis_ext,
+       metric_oper_ext,
+       n_vol_quad_pts_ext,
+       entropy_var_phys_grad_ext);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> entropy_var_jump_at_face;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            entropy_var_jump_at_face[s][d].resize(n_face_quad_pts);
+        }
+    }
+
+
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            for(unsigned int iquad=0; iquad<n_face_quad_pts; ++iquad)
+            {
+                entropy_var_jump_at_face[s][d][iquad] = (entropy_var_at_surf_int[s][iquad] - entropy_var_at_surf_ext[s][iquad])*unit_phys_normal_int[iquad][d];
+            }
+        }
+    }
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> re_int;
+    const bool is_interior_face = true;
+    compute_lift_polynomial(
+    face_orientation_int,
+    iface_int,
+    entropy_var_jump_at_face,
+    JxW_face,
+    JxW_vol_int,
+    flux_basis_int,
+    n_face_quad_pts,
+    n_vol_quad_pts_int,
+    is_interior_face,
+    re_int);
+    
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> re_ext;
+    compute_lift_polynomial(
+    face_orientation_ext,
+    iface_ext,
+    entropy_var_jump_at_face,
+    JxW_face,
+    JxW_vol_ext,
+    flux_basis_ext,
+    n_face_quad_pts,
+    n_vol_quad_pts_ext,
+    is_interior_face,
+    re_ext);
+
+    const double br2_factor = 2.0*dim + 1.0; // n_faces = 2*dim. br2_factor > n_faces for entropy stability.
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> tensor_int;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> tensor_ext;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            tensor_int[s][d].resize(n_vol_quad_pts_int);
+            tensor_ext[s][d].resize(n_vol_quad_pts_ext);
+        }
+    }
+    
+    for(unsigned int q=0; q<n_vol_quad_pts_int; ++q)
+    {
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                tensor_int[s][d][q] = entropy_var_phys_grad_int[s][d][q] + br2_factor*re_int[s][d][q];
+            }
+        }       
+    }
+
+    for(unsigned int q=0; q<n_vol_quad_pts_ext; ++q)
+    {
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                tensor_ext[s][d][q] = entropy_var_phys_grad_ext[s][d][q] + br2_factor*re_ext[s][d][q];
+            }
+        }       
+    }
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> K_tensor_int;
+    apply_diffusion_matrix_entropy_based(
+    entropy_var_at_vol_int,
+    n_vol_quad_pts_int,
+    pde_physics,
+    tensor_int,
+    K_tensor_int);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> K_tensor_ext;
+    apply_diffusion_matrix_entropy_based(
+    entropy_var_at_vol_ext,
+    n_vol_quad_pts_ext,
+    pde_physics,
+    tensor_ext,
+    K_tensor_ext);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> sigma_at_face_int;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> sigma_at_face_ext;
+    std::array<std::vector<adtype>,nstate> sigma_at_face_avg_dot_n_int;
+    std::array<std::vector<adtype>,nstate> sigma_at_face_avg_dot_n_ext;
+
+
+    interpolate_to_face(
+    face_orientation_int,
+    iface_int,
+    K_tensor_int,
+    flux_basis_int,
+    n_face_quad_pts,
+    sigma_at_face_int);
+    
+    interpolate_to_face(
+    face_orientation_ext,
+    iface_ext,
+    K_tensor_ext,
+    flux_basis_ext,
+    n_face_quad_pts,
+    sigma_at_face_ext);
+
+    // compute sigma_avg_dot_n
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        sigma_at_face_avg_dot_n_int[s].resize(n_face_quad_pts);
+        sigma_at_face_avg_dot_n_ext[s].resize(n_face_quad_pts);
+        for(unsigned int q=0; q<n_face_quad_pts; ++q)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                sigma_at_face_avg_dot_n_int[s][q] += 0.5*(sigma_at_face_int[s][d][q] + sigma_at_face_ext[s][d][q])*unit_phys_normal_int[q][d];
+                sigma_at_face_avg_dot_n_ext[s][q] += 0.5*(sigma_at_face_int[s][d][q] + sigma_at_face_ext[s][d][q])*(-unit_phys_normal_int[q][d]);
+            }
+        }
+    }
+
+    std::vector<adtype> int_face_integral_e;
+    std::vector<adtype> ext_face_integral_e;
+    std::vector<adtype> int_face_integral_k;
+    std::vector<adtype> ext_face_integral_k;
+    
+    evaluate_face_integral(
+    face_orientation_int,
+    iface_int,
+    sigma_at_face_avg_dot_n_int,
+    JxW_face,
+    soln_basis_int,
+    n_dofs_cell_int,
+    int_face_integral_e);
+    
+    evaluate_face_integral(
+    face_orientation_ext,
+    iface_ext,
+    sigma_at_face_avg_dot_n_ext,
+    JxW_face,
+    soln_basis_ext,
+    n_dofs_cell_ext,
+    ext_face_integral_e);
+
+    compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+    entropy_var_at_vol_int,
+    n_vol_quad_pts_int,
+    n_dofs_cell_int,
+    soln_basis_int,
+    metric_oper_int,
+    vol_quad_weights_int,
+    pde_physics,
+    re_int,
+    int_face_integral_k);
+
+    compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+    entropy_var_at_vol_ext,
+    n_vol_quad_pts_ext,
+    n_dofs_cell_ext,
+    soln_basis_ext,
+    metric_oper_ext,
+    vol_quad_weights_ext,
+    pde_physics,
+    re_ext,
+    ext_face_integral_k);
+
+    for(unsigned int idof =0; idof<n_dofs_cell_int; ++idof)
+    {
+        face_term_int[idof] = int_face_integral_k[idof] - int_face_integral_e[idof];
+    }
+
+    for(unsigned int idof =0; idof<n_dofs_cell_ext; ++idof)
+    {
+        face_term_ext[idof] = ext_face_integral_k[idof] - ext_face_integral_e[idof];
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_entropystable_br2(
+    std::vector<bool>                                                  face_orientation,
+    const unsigned int                                                 iface,
+    const unsigned int                                                 boundary_id,
+    const unsigned int                                                 poly_degree,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
+    const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
+    const unsigned int                                                  n_vol_quad_pts,
+    const unsigned int                                                  n_face_quad_pts,
+    const unsigned int                                                  n_dofs_cell,
+    OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+    OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
+    OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+    const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal,
+    const std::vector<adtype>                                          &JxW_face,
+    const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+    std::vector<adtype>                                                &boundary_term) const
+{
+    const std::vector<double> &vol_quad_weights = this->volume_quadrature_collection[poly_degree].get_weights();
+    std::vector<adtype> JxW_vol(n_vol_quad_pts);
+    for(unsigned int iquad=0; iquad<n_vol_quad_pts; ++iquad)
+    {
+        JxW_vol[iquad] = metric_oper.det_Jac_vol[iquad]*vol_quad_weights[iquad];
+    }
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       entropy_var_phys_grad_at_vol;
+    compute_physical_grad_entropy_var(
+    entropy_var_coeff,
+    soln_basis,
+    metric_oper,
+    n_vol_quad_pts,
+    entropy_var_phys_grad_at_vol);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       K_nabla_v_at_vol;
+    apply_diffusion_matrix_entropy_based(
+    entropy_var_at_vol_quads,
+    n_vol_quad_pts,
+    pde_physics,
+    entropy_var_phys_grad_at_vol,
+    K_nabla_v_at_vol);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       poly_K_nabla_v_at_face;
+    interpolate_to_face(
+    face_orientation,
+    iface,
+    K_nabla_v_at_vol,
+    flux_basis,
+    n_face_quad_pts,
+    poly_K_nabla_v_at_face);
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       entropy_var_phys_grad_at_face; // Using the vol entropy grad's projection to polynomial here instead of actually computing phys grad at face quadratures. This is consistent and should yield correct solutions under mesh refinement.
+    interpolate_to_face(
+    face_orientation,
+    iface,
+    entropy_var_phys_grad_at_vol,
+    flux_basis,
+    n_face_quad_pts,
+    entropy_var_phys_grad_at_face);
+    // continue from line 3480
+}
 
 
 #if PHILIP_SPECIES==1

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1060,6 +1060,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     std::array<std::vector<adtype>,nstate> legendre_soln_at_q;
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> legendre_aux_soln_at_q; // legendre auxiliary sol at flux nodes
     if(this->do_compute_filtered_solution) {
+        // NOTE: This only pertains to advanced SGS models for LES
         compute_filtered_solution_volume(
         legendre_soln_at_q,
         legendre_aux_soln_at_q,
@@ -1777,210 +1778,17 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> legendre_aux_soln_at_surf_q; // legendre auxiliary sol at flux nodes
     if(this->do_compute_filtered_solution) {
         // NOTE: This only pertains to advanced SGS models for LES
-        //==================================================
-        // GET THE PRIMITIVE SOLUTION
-        //==================================================
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_vol_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_vol_q;
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_surf_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_surf_q;
-        // Resize the primitive soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            primitive_soln_at_vol_q[istate].resize(n_quad_pts_vol);
-            primitive_soln_at_surf_q[istate].resize(n_face_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                primitive_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
-                primitive_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        // -- volume
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_vol_q[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_vol_q[istate][idim][iquad];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_vol_q[istate][iquad] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_vol_q[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface
-        for(unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++){
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_surf_q[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_surf_q[istate][idim][iquad_face];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_surf_q[istate][iquad_face] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_surf_q[istate][idim][iquad_face] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
+        compute_filtered_solution_volume_and_face(
+        soln_at_vol_q, 
+        aux_soln_at_vol_q,
+        pde_physics,
+        soln_at_surf_q,
+        aux_soln_at_surf_q,
+        n_quad_pts_vol,
+        n_face_quad_pts,
+        n_shape_fns,
+        poly_degree);
 
-        //==================================================
-        // PROJECT TO LEGENDRE BASIS AND MODALLY FILTER
-        //==================================================
-        // -- Primitive solution at legendre poly
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_vol_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_vol_q;
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_surf_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_surf_q;
-
-        // Details: this projects to Legendre basis, truncates, then interpolates back to quad nodes.
-        // -- Constructor for tensor product polynomials based on Polynomials::Legendre interpolation. 
-        dealii::FE_DGQLegendre<1,1> legendre_poly_1D(poly_degree);
-        // -- Projection operator for legendre basis
-        OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper(1, poly_degree, this->max_grid_degree);
-        legendre_soln_basis_projection_oper.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
-        // -- Legendre basis functions 
-        OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis(1, poly_degree, this->max_grid_degree);
-        legendre_soln_basis.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
-        legendre_soln_basis.build_1D_surface_operator(legendre_poly_1D, this->oneD_face_quadrature);
-        const unsigned int p_min_filtered = this->poly_degree_max_large_scales + 1;
-        for(int istate=0; istate<nstate; istate++){
-            //==================================================
-            // Solution
-            //==================================================
-            // -- (1) Project to Legendre basis
-            std::vector<adtype> legendre_soln_coeff(n_shape_fns);
-            legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_soln_at_vol_q[istate], legendre_soln_coeff,
-                                                                      legendre_soln_basis_projection_oper.oneD_vol_operator);
-            // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-            if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                    if(ishape < p_min_filtered){
-                        legendre_soln_coeff[ishape] = 0.0;
-                    }
-                }    
-            }
-            // -- (3) Interpolate filtered solution back to quadrature points
-            primitive_legendre_soln_at_vol_q[istate].resize(n_quad_pts_vol);
-            legendre_soln_basis.matrix_vector_mult_1D(legendre_soln_coeff, primitive_legendre_soln_at_vol_q[istate],
-                                                      legendre_soln_basis.oneD_vol_operator);
-            primitive_legendre_soln_at_surf_q[istate].resize(n_face_quad_pts);
-            legendre_soln_basis.matrix_vector_mult_surface_1D(face_orientation, 
-                                                              iface,
-                                                              legendre_soln_coeff, primitive_legendre_soln_at_surf_q[istate],
-                                                              legendre_soln_basis.oneD_surf_operator,
-                                                              legendre_soln_basis.oneD_vol_operator);
-            //==================================================
-
-            //==================================================
-            // Auxiliary Solution (gradients)
-            //==================================================
-            dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff;
-            for(int idim=0; idim<dim; idim++){
-                // -- (1) Project to Legendre basis
-                legendre_aux_soln_coeff[idim].resize(n_shape_fns);
-                if(this->use_auxiliary_eq){
-                    legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_aux_soln_at_vol_q[istate][idim], legendre_aux_soln_coeff[idim],
-                                                                              legendre_soln_basis_projection_oper.oneD_vol_operator);
-                    // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-                    if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                        for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                            if(ishape < p_min_filtered){
-                                legendre_aux_soln_coeff[idim][ishape] = 0.0;
-                            }
-                        }
-                    }
-                }
-                else {
-                    for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                        legendre_aux_soln_coeff[idim][ishape] = 0.0;
-                    }
-                }
-                // -- (3) Interpolate filtered solution back to quadrature points
-                primitive_legendre_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
-                legendre_soln_basis.matrix_vector_mult_1D(legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_vol_q[istate][idim],
-                                                          legendre_soln_basis.oneD_vol_operator);
-                primitive_legendre_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
-                legendre_soln_basis.matrix_vector_mult_surface_1D(face_orientation, 
-                                                                  iface,
-                                                                  legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_surf_q[istate][idim],
-                                                                  legendre_soln_basis.oneD_surf_operator,
-                                                                  legendre_soln_basis.oneD_vol_operator);
-            }
-            //==================================================
-        }
-        //=======================================================
-        // CONVERT PRIMITIVE LEGENDRE SOLUTION TO CONSERVATIVE
-        //=======================================================
-        // Resize the conservative soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            legendre_soln_at_vol_q[istate].resize(n_quad_pts_vol);
-            legendre_soln_at_surf_q[istate].resize(n_face_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                legendre_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
-                legendre_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        // -- volume
-        for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_vol_q[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_vol_q[istate][idim][iquad];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_vol_q[istate][iquad] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_vol_q[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        // -- surface
-        for (unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_surf_q[istate][iquad_face];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_surf_q[istate][idim][iquad_face];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_surf_q[istate][iquad_face] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_surf_q[istate][idim][iquad_face] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
     }
 
     // Get volume reference fluxes and interpolate them to the facet.
@@ -2421,6 +2229,226 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_boundary_term_strong(
 
         for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
             local_rhs_cell[istate*n_shape_fns + ishape] += rhs[ishape];
+        }
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
+void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volume_and_face(
+    const std::array<std::vector<adtype>,nstate> &soln_at_vol_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
+    pde_physics,
+    const std::array<std::vector<adtype>,nstate> &soln_at_surf_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
+    n_quad_pts_vol,
+    n_face_quad_pts,
+    n_shape_fns,
+    poly_degree)
+{
+    // NOTE: This only pertains to advanced SGS models for LES
+    //==================================================
+    // GET THE PRIMITIVE SOLUTION
+    //==================================================
+    std::array<std::vector<adtype>,nstate> primitive_soln_at_vol_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_vol_q;
+    std::array<std::vector<adtype>,nstate> primitive_soln_at_surf_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_surf_q;
+    // Resize the primitive soln arrays
+    for(int istate=0; istate<nstate; istate++){
+        primitive_soln_at_vol_q[istate].resize(n_quad_pts_vol);
+        primitive_soln_at_surf_q[istate].resize(n_face_quad_pts);
+        for(int idim=0; idim<dim; idim++){
+            primitive_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+            primitive_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
+        }
+    }
+    // Compute the primitive soln at all iquad and fill arrays
+    // -- volume
+    for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
+        // extract conservative soln state
+        std::array<adtype,nstate> soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            soln_state[istate] = soln_at_vol_q[istate][iquad];
+            for(int idim=0; idim<dim; idim++){
+                aux_soln_state[istate][idim] = aux_soln_at_vol_q[istate][idim][iquad];
+            }
+        }
+        // compute primitive soln state from conservative
+        std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
+        // store primitive soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            primitive_soln_at_vol_q[istate][iquad] = primitive_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                primitive_aux_soln_at_vol_q[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
+            }
+        }
+    }
+    // -- surface
+    for(unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++){
+        // extract conservative soln state
+        std::array<adtype,nstate> soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            soln_state[istate] = soln_at_surf_q[istate][iquad_face];
+            for(int idim=0; idim<dim; idim++){
+                aux_soln_state[istate][idim] = aux_soln_at_surf_q[istate][idim][iquad_face];
+            }
+        }
+        // compute primitive soln state from conservative
+        std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
+        // store primitive soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            primitive_soln_at_surf_q[istate][iquad_face] = primitive_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                primitive_aux_soln_at_surf_q[istate][idim][iquad_face] = primitive_aux_soln_state[istate][idim];
+            }
+        }
+    }
+
+    //==================================================
+    // PROJECT TO LEGENDRE BASIS AND MODALLY FILTER
+    //==================================================
+    // -- Primitive solution at legendre poly
+    std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_vol_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_vol_q;
+    std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_surf_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_surf_q;
+
+    // Details: this projects to Legendre basis, truncates, then interpolates back to quad nodes.
+    // -- Constructor for tensor product polynomials based on Polynomials::Legendre interpolation. 
+    dealii::FE_DGQLegendre<1,1> legendre_poly_1D(poly_degree);
+    // -- Projection operator for legendre basis
+    OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper(1, poly_degree, this->max_grid_degree);
+    legendre_soln_basis_projection_oper.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
+    // -- Legendre basis functions 
+    OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis(1, poly_degree, this->max_grid_degree);
+    legendre_soln_basis.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
+    legendre_soln_basis.build_1D_surface_operator(legendre_poly_1D, this->oneD_face_quadrature);
+    const unsigned int p_min_filtered = this->poly_degree_max_large_scales + 1;
+    for(int istate=0; istate<nstate; istate++){
+        //==================================================
+        // Solution
+        //==================================================
+        // -- (1) Project to Legendre basis
+        std::vector<adtype> legendre_soln_coeff(n_shape_fns);
+        legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_soln_at_vol_q[istate], legendre_soln_coeff,
+                                                                  legendre_soln_basis_projection_oper.oneD_vol_operator);
+        // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
+        if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
+            for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                if(ishape < p_min_filtered){
+                    legendre_soln_coeff[ishape] = 0.0;
+                }
+            }    
+        }
+        // -- (3) Interpolate filtered solution back to quadrature points
+        primitive_legendre_soln_at_vol_q[istate].resize(n_quad_pts_vol);
+        legendre_soln_basis.matrix_vector_mult_1D(legendre_soln_coeff, primitive_legendre_soln_at_vol_q[istate],
+                                                  legendre_soln_basis.oneD_vol_operator);
+        primitive_legendre_soln_at_surf_q[istate].resize(n_face_quad_pts);
+        legendre_soln_basis.matrix_vector_mult_surface_1D(face_orientation, 
+                                                          iface,
+                                                          legendre_soln_coeff, primitive_legendre_soln_at_surf_q[istate],
+                                                          legendre_soln_basis.oneD_surf_operator,
+                                                          legendre_soln_basis.oneD_vol_operator);
+        //==================================================
+
+        //==================================================
+        // Auxiliary Solution (gradients)
+        //==================================================
+        dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff;
+        for(int idim=0; idim<dim; idim++){
+            // -- (1) Project to Legendre basis
+            legendre_aux_soln_coeff[idim].resize(n_shape_fns);
+            if(this->use_auxiliary_eq){
+                legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_aux_soln_at_vol_q[istate][idim], legendre_aux_soln_coeff[idim],
+                                                                          legendre_soln_basis_projection_oper.oneD_vol_operator);
+                // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
+                if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
+                    for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                        if(ishape < p_min_filtered){
+                            legendre_aux_soln_coeff[idim][ishape] = 0.0;
+                        }
+                    }
+                }
+            }
+            else {
+                for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                    legendre_aux_soln_coeff[idim][ishape] = 0.0;
+                }
+            }
+            // -- (3) Interpolate filtered solution back to quadrature points
+            primitive_legendre_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+            legendre_soln_basis.matrix_vector_mult_1D(legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_vol_q[istate][idim],
+                                                      legendre_soln_basis.oneD_vol_operator);
+            primitive_legendre_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
+            legendre_soln_basis.matrix_vector_mult_surface_1D(face_orientation, 
+                                                              iface,
+                                                              legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_surf_q[istate][idim],
+                                                              legendre_soln_basis.oneD_surf_operator,
+                                                              legendre_soln_basis.oneD_vol_operator);
+        }
+        //==================================================
+    }
+    //=======================================================
+    // CONVERT PRIMITIVE LEGENDRE SOLUTION TO CONSERVATIVE
+    //=======================================================
+    // Resize the conservative soln arrays
+    for(int istate=0; istate<nstate; istate++){
+        legendre_soln_at_vol_q[istate].resize(n_quad_pts_vol);
+        legendre_soln_at_surf_q[istate].resize(n_face_quad_pts);
+        for(int idim=0; idim<dim; idim++){
+            legendre_aux_soln_at_vol_q[istate][idim].resize(n_quad_pts_vol);
+            legendre_aux_soln_at_surf_q[istate][idim].resize(n_face_quad_pts);
+        }
+    }
+    // Compute the primitive soln at all iquad and fill arrays
+    // -- volume
+    for (unsigned int iquad=0; iquad<n_quad_pts_vol; ++iquad) {
+        // extract conservative soln state
+        std::array<adtype,nstate> primitive_legendre_soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_vol_q[istate][iquad];
+            for(int idim=0; idim<dim; idim++){
+                primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_vol_q[istate][idim][iquad];
+            }
+        }
+        // compute conservative soln state from primitive
+        std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
+        // store conservative soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            legendre_soln_at_vol_q[istate][iquad] = legendre_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                legendre_aux_soln_at_vol_q[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
+            }
+        }
+    }
+    // -- surface
+    for (unsigned int iquad_face=0; iquad_face<n_face_quad_pts; iquad_face++) {
+        // extract conservative soln state
+        std::array<adtype,nstate> primitive_legendre_soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_surf_q[istate][iquad_face];
+            for(int idim=0; idim<dim; idim++){
+                primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_surf_q[istate][idim][iquad_face];
+            }
+        }
+        // compute conservative soln state from primitive
+        std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
+        // store conservative soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            legendre_soln_at_surf_q[istate][iquad_face] = legendre_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                legendre_aux_soln_at_surf_q[istate][idim][iquad_face] = legendre_aux_soln_state[istate][idim];
+            }
         }
     }
 }

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -4229,7 +4229,110 @@ void EntropyStable_viscousBR2<dim,nspecies,nstate,real,MeshType>::assemble_bound
     flux_basis,
     n_face_quad_pts,
     entropy_var_phys_grad_at_face);
-    // continue from line 3480
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>      jump_entropy_var_face;
+    std::array<std::vector<adtype>,nstate> sigma_gamma_dot_n_face;
+    for(unsigned int s=0; s<nstate; ++s)
+    {
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            jump_entropy_var_face[s][d].resize(n_face_quad_pts);
+        }
+        sigma_gamma_dot_n_face[s].resize(n_face_quad_pts); // 0 by default
+    }
+
+    for(unsigned int q =0; q<n_face_quad_pts; ++q)
+    {
+        std::array<adtype,nstate> v_int_at_q;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> poly_sigma_at_q;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> entropy_var_phys_grad_face_q;
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                poly_sigma_at_q[s][d] = poly_K_nabla_v_at_face[s][d][q];
+                entropy_var_phys_grad_face_q[s][d] = entropy_var_phys_grad_at_face[s][d][q];
+            }
+            v_int_at_q[s] = entropy_var_at_surf_quads[s][q];
+        }
+        dealii::Point<dim,adtype> surf_flux_node;
+        for(int idim=0; idim<dim; idim++){
+            surf_flux_node[idim] = metric_oper.flux_nodes_surf[iface][idim][q];
+        }
+        
+        std::array<adtype,nstate> v_bc_at_q;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> sigma_bc_at_q;
+
+
+        pde_physics.boundary_face_values_entropy_var(surf_flux_node,
+                                                     v_int_at_q, 
+                                                     poly_sigma_at_q, 
+                                                     entropy_var_phys_grad_face_q, 
+                                                     v_bc_at_q, 
+                                                     sigma_bc_at_q, 
+                                                     unit_phys_normal[q],
+                                                     boundary_id);
+
+
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                sigma_gamma_dot_n_face[s][q] += sigma_bc_at_q[s][d]*unit_phys_normal[q][d];
+            }
+        }
+
+
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                jump_entropy_var_face[s][d][q] = (v_bc_at_q[s] - v_int_at_q[s])*unit_phys_normal[q][d];
+            }
+        }
+    }
+
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>      re_jump;
+    const bool is_interior_face = false;
+    compute_lift_polynomial(
+    face_orientation,
+    iface,
+    jump_entropy_var_face,
+    JxW_face,
+    JxW_vol,
+    flux_basis,
+    n_face_quad_pts,
+    n_vol_quad_pts,
+    is_interior_face,
+    re_jump);
+
+    std::vector<adtype> integral_k;
+    std::vector<adtype> integral_e;
+    evaluate_face_integral(
+    face_orientation,
+    iface,
+    sigma_gamma_dot_n_face,
+    JxW_face,
+    soln_basis,
+    n_dofs_cell,
+    integral_e);
+
+    compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+    entropy_var_at_vol_quads,
+    n_vol_quad_pts,
+    n_dofs_cell,
+    soln_basis,
+    metric_oper,
+    vol_quad_weights,
+    pde_physics,
+    re_jump,
+    integral_k);
+
+    boundary_term.resize(n_dofs_cell);
+    for(unsigned int idof=0; idof<n_dofs_cell; ++idof)
+    {
+        boundary_term[idof] = integral_k[idof] - integral_e[idof];
+    }
 }
 
 

--- a/src/dg/strong_dg.cpp
+++ b/src/dg/strong_dg.cpp
@@ -1038,6 +1038,7 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
 
 
     std::array<std::vector<adtype>,nstate> soln_at_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> aux_soln_at_q; //auxiliary sol at flux nodes
     std::vector<std::array<double,nstate>> soln_at_q_for_max_CFL(n_quad_pts);//Need soln written in a different for to use pre-existing max CFL function
     // Interpolate each state to the quadrature points using sum-factorization
     // with the basis functions in each reference direction.
@@ -1045,6 +1046,11 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
         soln_at_q[istate].resize(n_quad_pts);
         soln_basis.matrix_vector_mult_1D(soln_coeff[istate], soln_at_q[istate],
                                          soln_basis.oneD_vol_operator);
+        for(int idim=0; idim<dim; idim++){
+            aux_soln_at_q[istate][idim].resize(n_quad_pts);
+            soln_basis.matrix_vector_mult_1D(aux_soln_coeff[istate][idim], aux_soln_at_q[istate][idim],
+                                             soln_basis.oneD_vol_operator);
+        }
         for(unsigned int iquad=0; iquad<n_quad_pts; iquad++){
             soln_at_q_for_max_CFL[iquad][istate] = getValue<adtype>(soln_at_q[istate][iquad]);
         }
@@ -1054,144 +1060,14 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     std::array<std::vector<adtype>,nstate> legendre_soln_at_q;
     std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> legendre_aux_soln_at_q; // legendre auxiliary sol at flux nodes
     if(this->do_compute_filtered_solution) {
-        // NOTE: This only pertains to advanced SGS models for LES
-        //==================================================
-        // GET THE PRIMITIVE SOLUTION
-        //==================================================
-        std::array<std::vector<adtype>,nstate> primitive_soln_at_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_q; // primitive auxiliary sol at flux nodes
-        // Resize the primitive soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            primitive_soln_at_q[istate].resize(n_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                primitive_aux_soln_at_q[istate][idim].resize(n_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                soln_state[istate] = soln_at_q[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    aux_soln_state[istate][idim] = aux_soln_at_q[istate][idim][iquad];
-                }
-            }
-            // compute primitive soln state from conservative
-            std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
-            // store primitive soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                primitive_soln_at_q[istate][iquad] = primitive_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_aux_soln_at_q[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
-                }
-            }
-        }
-        
-        //==================================================
-        // PROJECT TO LEGENDRE BASIS AND MODALLY FILTER
-        //==================================================
-        // -- Primitive solution at legendre poly
-        std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_q;
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_q; // legendre auxiliary sol at flux nodes
-
-        // Details: this projects to Legendre basis, truncates, then interpolates back to quad nodes.
-        // -- Constructor for tensor product polynomials based on Polynomials::Legendre interpolation. 
-        dealii::FE_DGQLegendre<1,1> legendre_poly_1D(poly_degree);
-        // -- Projection operator for legendre basis
-        OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper(1, poly_degree, this->max_grid_degree);
-        legendre_soln_basis_projection_oper.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
-        // -- Legendre basis functions 
-        OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis(1, poly_degree, this->max_grid_degree);
-        legendre_soln_basis.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
-        const unsigned int p_min_filtered = this->poly_degree_max_large_scales + 1;
-        for(int istate=0; istate<nstate; istate++){
-            //==================================================
-            // Solution
-            //==================================================
-            // -- (1) Project to Legendre basis
-            std::vector<adtype> legendre_soln_coeff(n_shape_fns);
-            legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_soln_at_q[istate], legendre_soln_coeff,
-                                                                      legendre_soln_basis_projection_oper.oneD_vol_operator);
-            // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-            if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                    if(ishape < p_min_filtered){
-                        legendre_soln_coeff[ishape] = 0.0;
-                    }
-                }    
-            }
-            // -- (3) Interpolate filtered solution back to quadrature points
-            primitive_legendre_soln_at_q[istate].resize(n_quad_pts);
-            legendre_soln_basis.matrix_vector_mult_1D(legendre_soln_coeff, primitive_legendre_soln_at_q[istate],
-                                                      legendre_soln_basis.oneD_vol_operator);
-            //==================================================
-
-            //==================================================
-            // Auxiliary Solution (gradients)
-            //==================================================
-            dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff;
-            for(int idim=0; idim<dim; idim++){
-                // -- (1) Project to Legendre basis
-                legendre_aux_soln_coeff[idim].resize(n_shape_fns);
-                if(this->use_auxiliary_eq){
-                    legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_aux_soln_at_q[istate][idim], legendre_aux_soln_coeff[idim],
-                                                                              legendre_soln_basis_projection_oper.oneD_vol_operator);
-                    // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
-                    if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
-                        for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                            if(ishape < p_min_filtered){
-                                legendre_aux_soln_coeff[idim][ishape] = 0.0;
-                            }
-                        }    
-                    }
-                }
-                else {
-                    for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
-                        legendre_aux_soln_coeff[idim][ishape] = 0.0;
-                    }
-                }
-                // -- (3) Interpolate filtered solution back to quadrature points
-                primitive_legendre_aux_soln_at_q[istate][idim].resize(n_quad_pts);
-                legendre_soln_basis.matrix_vector_mult_1D(legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_q[istate][idim],
-                                                          legendre_soln_basis.oneD_vol_operator);
-            }
-            //==================================================
-        }
-        //=======================================================
-        // CONVERT PRIMITIVE LEGENDRE SOLUTION TO CONSERVATIVE
-        //=======================================================
-        // Resize the conservative soln arrays
-        for(int istate=0; istate<nstate; istate++){
-            legendre_soln_at_q[istate].resize(n_quad_pts);
-            for(int idim=0; idim<dim; idim++){
-                legendre_aux_soln_at_q[istate][idim].resize(n_quad_pts);
-            }
-        }
-        // Compute the primitive soln at all iquad and fill arrays
-        for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
-            // extract conservative soln state
-            std::array<adtype,nstate> primitive_legendre_soln_state;
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
-            for(int istate=0; istate<nstate; istate++){
-                primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_q[istate][iquad];
-                for(int idim=0; idim<dim; idim++){
-                    primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_q[istate][idim][iquad];
-                }
-            }
-            // compute conservative soln state from primitive
-            std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
-            std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
-            // store conservative soln at quadrature point
-            for(int istate=0; istate<nstate; istate++){
-                legendre_soln_at_q[istate][iquad] = legendre_soln_state[istate];
-                for(int idim=0; idim<dim; idim++){
-                    legendre_aux_soln_at_q[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
-                }
-            }
-        }
+        compute_filtered_solution_volume(
+        legendre_soln_at_q,
+        legendre_aux_soln_at_q,
+        n_quad_pts,
+        poly_degree,
+        pde_physics,
+        soln_at_q,
+        aux_soln_at_q);
     }
 
     // For pseudotime, we need to compute the time_scaled_solution.
@@ -1574,6 +1450,157 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_strong(
     
 template <int dim, int nspecies, int nstate, typename real, typename MeshType>
 template <typename adtype>
+void DGStrong<dim,nspecies,nstate,real,MeshType>::compute_filtered_solution_volume(
+    std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
+    const unsigned int n_quad_pts,
+    const unsigned int poly_degree,
+    const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+    const std::array<std::vector<adtype>,nstate> &soln_at_q,
+    const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q)
+{
+    // NOTE: This only pertains to advanced SGS models for LES
+    //==================================================
+    // GET THE PRIMITIVE SOLUTION
+    //==================================================
+    std::array<std::vector<adtype>,nstate> primitive_soln_at_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_aux_soln_at_q; // primitive auxiliary sol at flux nodes
+    // Resize the primitive soln arrays
+    for(int istate=0; istate<nstate; istate++){
+        primitive_soln_at_q[istate].resize(n_quad_pts);
+        for(int idim=0; idim<dim; idim++){
+            primitive_aux_soln_at_q[istate][idim].resize(n_quad_pts);
+        }
+    }
+    // Compute the primitive soln at all iquad and fill arrays
+    for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
+        // extract conservative soln state
+        std::array<adtype,nstate> soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            soln_state[istate] = soln_at_q[istate][iquad];
+            for(int idim=0; idim<dim; idim++){
+                aux_soln_state[istate][idim] = aux_soln_at_q[istate][idim][iquad];
+            }
+        }
+        // compute primitive soln state from conservative
+        std::array<adtype,nstate> primitive_soln_state = pde_physics.convert_conservative_to_primitive(soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_aux_soln_state = pde_physics.convert_conservative_gradient_to_primitive_gradient(soln_state,aux_soln_state);
+        // store primitive soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            primitive_soln_at_q[istate][iquad] = primitive_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                primitive_aux_soln_at_q[istate][idim][iquad] = primitive_aux_soln_state[istate][idim];
+            }
+        }
+    }
+    
+    //==================================================
+    // PROJECT TO LEGENDRE BASIS AND MODALLY FILTER
+    //==================================================
+    // -- Primitive solution at legendre poly
+    std::array<std::vector<adtype>,nstate> primitive_legendre_soln_at_q;
+    std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> primitive_legendre_aux_soln_at_q; // legendre auxiliary sol at flux nodes
+
+    // Details: this projects to Legendre basis, truncates, then interpolates back to quad nodes.
+    // -- Constructor for tensor product polynomials based on Polynomials::Legendre interpolation. 
+    dealii::FE_DGQLegendre<1,1> legendre_poly_1D(poly_degree);
+    // -- Projection operator for legendre basis
+    OPERATOR::vol_projection_operator<dim,2*dim> legendre_soln_basis_projection_oper(1, poly_degree, this->max_grid_degree);
+    legendre_soln_basis_projection_oper.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
+    // -- Legendre basis functions 
+    OPERATOR::basis_functions<dim,2*dim> legendre_soln_basis(1, poly_degree, this->max_grid_degree);
+    legendre_soln_basis.build_1D_volume_operator(legendre_poly_1D, this->oneD_quadrature_collection[poly_degree]);
+    const unsigned int p_min_filtered = this->poly_degree_max_large_scales + 1;
+    for(int istate=0; istate<nstate; istate++){
+        //==================================================
+        // Solution
+        //==================================================
+        // -- (1) Project to Legendre basis
+        std::vector<adtype> legendre_soln_coeff(n_shape_fns);
+        legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_soln_at_q[istate], legendre_soln_coeff,
+                                                                  legendre_soln_basis_projection_oper.oneD_vol_operator);
+        // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
+        if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
+            for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                if(ishape < p_min_filtered){
+                    legendre_soln_coeff[ishape] = 0.0;
+                }
+            }    
+        }
+        // -- (3) Interpolate filtered solution back to quadrature points
+        primitive_legendre_soln_at_q[istate].resize(n_quad_pts);
+        legendre_soln_basis.matrix_vector_mult_1D(legendre_soln_coeff, primitive_legendre_soln_at_q[istate],
+                                                  legendre_soln_basis.oneD_vol_operator);
+        //==================================================
+
+        //==================================================
+        // Auxiliary Solution (gradients)
+        //==================================================
+        dealii::Tensor<1,dim,std::vector<adtype>> legendre_aux_soln_coeff;
+        for(int idim=0; idim<dim; idim++){
+            // -- (1) Project to Legendre basis
+            legendre_aux_soln_coeff[idim].resize(n_shape_fns);
+            if(this->use_auxiliary_eq){
+                legendre_soln_basis_projection_oper.matrix_vector_mult_1D(primitive_aux_soln_at_q[istate][idim], legendre_aux_soln_coeff[idim],
+                                                                          legendre_soln_basis_projection_oper.oneD_vol_operator);
+                // -- (2) Truncate modes for high-pass filter (i.e. DG-VMS like)
+                if(this->apply_modal_high_pass_filter_on_filtered_solution && (istate!=0 && istate!=(nstate-1))) {
+                    for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                        if(ishape < p_min_filtered){
+                            legendre_aux_soln_coeff[idim][ishape] = 0.0;
+                        }
+                    }    
+                }
+            }
+            else {
+                for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                    legendre_aux_soln_coeff[idim][ishape] = 0.0;
+                }
+            }
+            // -- (3) Interpolate filtered solution back to quadrature points
+            primitive_legendre_aux_soln_at_q[istate][idim].resize(n_quad_pts);
+            legendre_soln_basis.matrix_vector_mult_1D(legendre_aux_soln_coeff[idim], primitive_legendre_aux_soln_at_q[istate][idim],
+                                                      legendre_soln_basis.oneD_vol_operator);
+        }
+        //==================================================
+    }
+    //=======================================================
+    // CONVERT PRIMITIVE LEGENDRE SOLUTION TO CONSERVATIVE
+    //=======================================================
+    // Resize the conservative soln arrays
+    for(int istate=0; istate<nstate; istate++){
+        legendre_soln_at_q[istate].resize(n_quad_pts);
+        for(int idim=0; idim<dim; idim++){
+            legendre_aux_soln_at_q[istate][idim].resize(n_quad_pts);
+        }
+    }
+    // Compute the primitive soln at all iquad and fill arrays
+    for (unsigned int iquad=0; iquad<n_quad_pts; ++iquad) {
+        // extract conservative soln state
+        std::array<adtype,nstate> primitive_legendre_soln_state;
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> primitive_legendre_aux_soln_state;
+        for(int istate=0; istate<nstate; istate++){
+            primitive_legendre_soln_state[istate] = primitive_legendre_soln_at_q[istate][iquad];
+            for(int idim=0; idim<dim; idim++){
+                primitive_legendre_aux_soln_state[istate][idim] = primitive_legendre_aux_soln_at_q[istate][idim][iquad];
+            }
+        }
+        // compute conservative soln state from primitive
+        std::array<adtype,nstate> legendre_soln_state = pde_physics.convert_primitive_to_conservative(primitive_legendre_soln_state);
+        std::array<dealii::Tensor<1,dim,adtype>,nstate> legendre_aux_soln_state = pde_physics.convert_primitive_gradient_to_conservative_gradient(primitive_legendre_soln_state,primitive_legendre_aux_soln_state);
+        // store conservative soln at quadrature point
+        for(int istate=0; istate<nstate; istate++){
+            legendre_soln_at_q[istate][iquad] = legendre_soln_state[istate];
+            for(int idim=0; idim<dim; idim++){
+                legendre_aux_soln_at_q[istate][idim][iquad] = legendre_aux_soln_state[istate][idim];
+            }
+        }
+    }
+}
+    
+template <int dim, int nspecies, int nstate, typename real, typename MeshType>
+template <typename adtype>
 void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_primal(
     const std::array<std::vector<adtype>,nstate>  &soln_coeff,
     const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_coeff,
@@ -1608,16 +1635,6 @@ void DGStrong<dim,nspecies,nstate,real,MeshType>::assemble_volume_term_viscous_p
     }
     else
     {
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> aux_soln_at_q; //auxiliary sol at flux nodes
-        // Interpolate each state to the quadrature points using sum-factorization
-        // with the basis functions in each reference direction.
-        for(int istate=0; istate<nstate; istate++){
-            for(int idim=0; idim<dim; idim++){
-                aux_soln_at_q[istate][idim].resize(n_quad_pts);
-                soln_basis.matrix_vector_mult_1D(aux_soln_coeff[istate][idim], aux_soln_at_q[istate][idim],
-                                                 soln_basis.oneD_vol_operator);
-            }
-        }
     }
 }
 

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -1033,29 +1033,32 @@ public:
     
 }; // end of DGStrong class
 
+/// Class containing functions pertaining to the entropy stable viscous discretization.
 #if PHILIP_DIM==1 // dealii::parallel::distributed::Triangulation<dim> does not work for 1D
 template <int dim, int nspecies, int nstate, typename real, typename MeshType = dealii::Triangulation<dim>>
 #else
 template <int dim, int nspecies, int nstate, typename real, typename MeshType = dealii::parallel::distributed::Triangulation<dim>>
 #endif
-class EntropyStable_viscousBR2: public DGStrong<dim, nspecies, nstate, real, MeshType>
+class EntropyStable_viscousBR2
 {
     public:
-        EntropyStable_viscousBR2();
+        EntropyStable_viscousBR2(){}
 
     private:
-    /// Projects values at the volume quadrature to obtain a polynomial and interpolates that polynomila to the face quadratures.
+    /// Projects tensor values at the volume quadrature to obtain a polynomial and interpolates that polynomial to the face quadratures.
     template <typename adtype>
     void interpolate_to_face(
+        std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_vol,
         OPERATOR::basis_functions<dim,2*dim> &flux_basis,
         const unsigned int n_face_quad_pts,
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face) const;
 
-    /// Evaluates integral at the face
+    /// Evaluates integral of a tensor at the face
     template <typename adtype>
     void evaluate_face_integral(
+        std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<std::vector<adtype>,nstate> &sigma_dot_n_at_face,
         const std::vector<adtype> &JxW_face,
@@ -1066,12 +1069,12 @@ class EntropyStable_viscousBR2: public DGStrong<dim, nspecies, nstate, real, Mes
     /// Computes polynomial based on the values at the face
     template <typename adtype>
     void compute_lift_polynomial(
+        std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &phi_at_face,
         const std::vector<adtype> &JxW_face,
         const std::vector<adtype> &JxW_vol,
         OPERATOR::basis_functions<dim,2*dim> &flux_basis,
-        const unsigned int n_face_quad_pts,
         const unsigned int n_vol_quad_pts,
         const bool is_interior_face,
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol) const;

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -847,11 +847,14 @@ public:
         dealii::Tensor<1,dim,std::vector<adtype>>          &local_auxiliary_RHS_ext);
 
 protected:
-    ///Evaluate the volume RHS for viscous term.
+    ///Evaluate volume RHS for the viscous term.
     template <typename adtype>
     void assemble_volume_term_viscous_primal(
-        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_coeff,
+        const dealii::types::global_dof_index                              current_cell_index,
+        const std::array<std::vector<adtype>,nstate> &soln_at_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q,
+        const std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
         const unsigned int                            poly_degree,
         OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
         OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
@@ -866,22 +869,85 @@ protected:
     ///Evaluate the boundary RHS for viscous term.
     template <typename adtype>
     void assemble_boundary_term_viscous_primal(
-        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-        const unsigned int                            poly_degree,
-        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
-        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
-        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
-        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+        const dealii::types::global_dof_index                              current_cell_index,
+        std::vector<bool>                                                  face_orientation,
+        const unsigned int                                                 iface,
+        const unsigned int                                                 boundary_id,
+        const unsigned int                                                 poly_degree,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q.
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q,
+        const unsigned int                                                 n_vol_quad_pts,  
+        const unsigned int                                                 n_face_quad_pts,  
+        const unsigned int                                                 n_dofs_cell, 
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+        const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normals,
+        const std::vector<adtype>                                          &JxW_face,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
+        std::vector<adtype>                                                &boundary_term_viscous) const;
     
     ///Evaluate the face RHS for viscous term.
     template <typename adtype>
     void assemble_face_term_viscous_primal(
-        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
-        const unsigned int                            poly_degree,
-        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
-        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
-        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
-        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+        const dealii::types::global_dof_index                              current_cell_index,
+        const dealii::types::global_dof_index                              neighbor_cell_index,
+        std::vector<bool>                                                  face_orientation_int,
+        std::vector<bool>                                                  face_orientation_ext,
+        const unsigned int                                                 iface_int,
+        const unsigned int                                                 iface_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int.
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_ext,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_int,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_ext,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_int,
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_ext,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_int,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext;
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_int,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_int,
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_ext,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_ext, 
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q_int,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q_int,
+        const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q_ext,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q_ext,
+        const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal_int,
+        const std::vector<adtype>                                          &JxW_face,
+        const unsigned int                                                  poly_degree_int,
+        const unsigned int                                                  poly_degree_ext,
+        const unsigned int                                                  n_quad_pts_vol_int,
+        const unsigned int                                                  n_quad_pts_vol_ext,
+        const unsigned int                                                  n_dofs_cell_int,
+        const unsigned int                                                  n_dofs_cell_ext,
+        const unsigned int                                                  n_face_quad_pts,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
+        std::vector<adtype>                                                &viscous_face_term_int,
+        std::vector<adtype>                                                &viscous_face_term_ext) const;
     
     /// Compute filtered solution in the volume
     template <typename adtype>

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -882,6 +882,21 @@ protected:
         OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
         dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+    
+    /// Compute filtered solution in the volume
+    template <typename adtype>
+    void compute_filtered_solution_volume(
+        std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
+        const unsigned int n_quad_pts,
+        const unsigned int poly_degree,
+        const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+        const std::array<std::vector<adtype>,nstate> &soln_at_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q);
+    
+    /// Compute filtered solution at the face
+    template <typename adtype>
+    void compute_filtered_solution_volume_and_face()
 
 protected:
     /// Strong form primary equation's volume right-hand-side.

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -1120,7 +1120,6 @@ class EntropyStable_viscousBR2
         const unsigned int                                                  n_quad_pts,
         const unsigned int                                                  n_dofs_cell,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
-        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
         const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
         std::vector<adtype>                                                &vol_term) const;

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -1127,6 +1127,8 @@ class EntropyStable_viscousBR2
     /// Assemble BR2 face term.
     template <typename adtype>
     void assemble_face_term_entropystable_br2(
+        std::vector<bool>                                                  face_orientation_int,
+        std::vector<bool>                                                  face_orientation_ext,
         const unsigned int                                                 iface_int,
         const unsigned int                                                 iface_ext,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
@@ -1157,6 +1159,7 @@ class EntropyStable_viscousBR2
     /// Assemble BR2 boundary term.
     template <typename adtype>
     void assemble_boundary_term_entropystable_br2(
+        std::vector<bool>                                                  face_orientation,
         const unsigned int                                                 iface,
         const unsigned int                                                 boundary_id,
         const unsigned int                                                 poly_degree,

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -847,6 +847,37 @@ public:
         dealii::Tensor<1,dim,std::vector<adtype>>          &local_auxiliary_RHS_ext);
 
 protected:
+    ///Evaluate the volume RHS for viscous term.
+    template <typename adtype>
+    void assemble_volume_term_viscous_primal(
+        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+        const unsigned int                            poly_degree,
+        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+    
+    ///Evaluate the boundary RHS for viscous term.
+    template <typename adtype>
+    void assemble_boundary_term_viscous_primal(
+        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+        const unsigned int                            poly_degree,
+        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+    
+    ///Evaluate the face RHS for viscous term.
+    template <typename adtype>
+    void assemble_face_term_viscous_primal(
+        const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+        const unsigned int                            poly_degree,
+        OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
+        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+
+protected:
     /// Strong form primary equation's volume right-hand-side.
     /**  We refer to Cicchino, Alexander, et al. "Provably stable flux reconstruction high-order methods on curvilinear elements." Journal of Computational Physics 463 (2022): 111259.
     * Conservative form Eq. (17): <br>
@@ -1001,6 +1032,146 @@ public:
     }
     
 }; // end of DGStrong class
+
+#if PHILIP_DIM==1 // dealii::parallel::distributed::Triangulation<dim> does not work for 1D
+template <int dim, int nspecies, int nstate, typename real, typename MeshType = dealii::Triangulation<dim>>
+#else
+template <int dim, int nspecies, int nstate, typename real, typename MeshType = dealii::parallel::distributed::Triangulation<dim>>
+#endif
+class EntropyStable_viscousBR2: public DGStrong<dim, nspecies, nstate, real, MeshType>
+{
+    public:
+        EntropyStable_viscousBR2();
+
+    private:
+    /// Projects values at the volume quadrature to obtain a polynomial and interpolates that polynomila to the face quadratures.
+    template <typename adtype>
+    void interpolate_to_face(
+        const unsigned int iface,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_vol,
+        OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+        const unsigned int n_face_quad_pts,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face) const;
+
+    /// Evaluates integral at the face
+    template <typename adtype>
+    void evaluate_face_integral(
+        const unsigned int iface,
+        const std::array<std::vector<adtype>,nstate> &sigma_dot_n_at_face,
+        const std::vector<adtype> &JxW_face,
+        OPERATOR::basis_functions<dim,2*dim> &soln_basis,
+        const unsigned int n_dofs_cell,
+        std::vector<adtype> &integral_val) const;
+
+    /// Computes polynomial based on the values at the face
+    template <typename adtype>
+    void compute_lift_polynomial(
+        const unsigned int iface,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &phi_at_face,
+        const std::vector<adtype> &JxW_face,
+        const std::vector<adtype> &JxW_vol,
+        OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+        const unsigned int n_face_quad_pts,
+        const unsigned int n_vol_quad_pts,
+        const bool is_interior_face,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol) const;
+
+    /// Computes physical gradient of the entropy variable
+    template <typename adtype>
+    void compute_physical_grad_entropy_var(
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+        const unsigned int                                                 n_quad_pts,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad) const;
+
+    /// Applies diffusion matrix entropy based (referred to as K in Jesse Chan's paper).
+    template <typename adtype>
+    void apply_diffusion_matrix_entropy_based(
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
+        const unsigned int                                                 n_quad_pts,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_in,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out) const;
+
+    
+    /// Computes the volume integral of gradient of basis times diffusion matrix times input tensor
+    template <typename adtype>
+    void compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
+        const unsigned int                                                 n_quad_pts,
+        const unsigned int                                                 n_dofs_cell,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+        const std::vector<double>                                          &weight_vect,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_input,
+        std::vector<adtype>                                                &integral_val) const;
+
+    /// Assemble BR2 volume term.
+    template <typename adtype>
+    void assemble_volume_term_entropystable_br2(
+        const unsigned int                                                 poly_degree,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_q,
+        const unsigned int                                                  n_quad_pts,
+        const unsigned int                                                  n_dofs_cell,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        std::vector<adtype>                                                &vol_term) const;
+
+    /// Assemble BR2 face term.
+    template <typename adtype>
+    void assemble_face_term_entropystable_br2(
+        const unsigned int                                                 iface_int,
+        const unsigned int                                                 iface_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
+        const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal_int,
+        const std::vector<adtype>                                          &JxW_face,
+        const unsigned int                                                  poly_degree_int,
+        const unsigned int                                                  poly_degree_ext,
+        const unsigned int                                                  n_vol_quad_pts_int,
+        const unsigned int                                                  n_vol_quad_pts_ext,
+        const unsigned int                                                  n_dofs_cell_int,
+        const unsigned int                                                  n_dofs_cell_ext,
+        const unsigned int                                                  n_face_quad_pts,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        std::vector<adtype>                                                &face_term_int,
+        std::vector<adtype>                                                &face_term_ext) const;
+
+    /// Assemble BR2 boundary term.
+    template <typename adtype>
+    void assemble_boundary_term_entropystable_br2(
+        const unsigned int                                                 iface,
+        const unsigned int                                                 boundary_id,
+        const unsigned int                                                 poly_degree,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
+        const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
+        const unsigned int                                                  n_vol_quad_pts,
+        const unsigned int                                                  n_face_quad_pts,
+        const unsigned int                                                  n_dofs_cell,
+        OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
+        OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
+        OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
+        const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal,
+        const std::vector<adtype>                                          &JxW_face,
+        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        std::vector<adtype>                                                &boundary_term) const;
+};
 
 } // PHiLiP namespace
 

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -863,7 +863,8 @@ protected:
         const std::array<std::vector<adtype>,nstate>  &entropy_var_at_q,
         const unsigned int  n_quad_pts,
         const unsigned int  n_dofs_cell,
-        const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+        const unsigned int  n_shape_fns,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype> &pde_physics,
         std::vector<adtype>     &vol_term_viscous) const;
     
     ///Evaluate the boundary RHS for viscous term.
@@ -874,6 +875,7 @@ protected:
         const unsigned int                                                 iface,
         const unsigned int                                                 boundary_id,
         const unsigned int                                                 poly_degree,
+        const real                                                         penalty,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_quads,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_quads,
@@ -881,7 +883,7 @@ protected:
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
         const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
-        const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q.
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_opposite_surf_q,
         const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
         const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_surf_q,
@@ -894,7 +896,7 @@ protected:
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
         const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normals,
         const std::vector<adtype>                                          &JxW_face,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
         const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
         std::vector<adtype>                                                &boundary_term_viscous) const;
     
@@ -907,20 +909,21 @@ protected:
         std::vector<bool>                                                  face_orientation_ext,
         const unsigned int                                                 iface_int,
         const unsigned int                                                 iface_ext,
+        const real                                                         penalty,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_int,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff_ext,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_int,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_vol_ext,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_int,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_surf_ext,
-        const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int.
+        const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_int,
         const std::array<std::vector<adtype>,nstate>                       &soln_at_vol_q_ext,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_int,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q_ext,
         const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_int,
         const std::array<std::vector<adtype>,nstate>                       &soln_at_surf_q_ext,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_int,
-        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext;
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q_ext,
         const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_int,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q_int,
         const std::array<std::vector<adtype>,nstate>                       &legendre_soln_at_vol_q_ext,
@@ -938,13 +941,15 @@ protected:
         const unsigned int                                                  n_dofs_cell_int,
         const unsigned int                                                  n_dofs_cell_ext,
         const unsigned int                                                  n_face_quad_pts,
+        const unsigned int                                                  n_shape_fns_int,
+        const unsigned int                                                  n_shape_fns_ext,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_int,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis_ext,
         OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_int,
         OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
         const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
         std::vector<adtype>                                                &viscous_face_term_int,
         std::vector<adtype>                                                &viscous_face_term_ext) const;
@@ -955,14 +960,17 @@ protected:
         std::array<std::vector<adtype>,nstate> &legendre_soln_at_q,
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_q,
         const unsigned int n_quad_pts,
+        const unsigned int n_shape_fns,
         const unsigned int poly_degree,
-        const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype> &pde_physics,
         const std::array<std::vector<adtype>,nstate> &soln_at_q,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q);
     
     /// Compute filtered solution at the face and volume
     template <typename adtype>
     void compute_filtered_solution_volume_and_face(
+        std::vector<bool>                                                  face_orientation,
+        const unsigned int                                                 iface,
         std::array<std::vector<adtype>,nstate> &legendre_soln_at_vol_q,
         std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
         std::array<std::vector<adtype>,nstate> &legendre_soln_at_surf_q,
@@ -1027,7 +1035,7 @@ protected:
         OPERATOR::basis_functions<dim,2*dim>                               &flux_basis,
         OPERATOR::vol_projection_operator<dim,2*dim>                       &soln_basis_projection_oper,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
-        Physics::PhysicsBase<dim, nspecies, nstate, adtype>                          &pde_physics,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype>                &pde_physics,
         const NumericalFlux::NumericalFluxConvective<dim, nspecies, nstate, adtype>  &conv_num_flux,
         const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
         std::vector<adtype>                                                &local_rhs_cell);
@@ -1064,7 +1072,7 @@ protected:
         OPERATOR::vol_projection_operator<dim,2*dim>                       &soln_basis_projection_oper_ext,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
-        Physics::PhysicsBase<dim, nspecies, nstate, adtype>                          &pde_physics,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype>                &pde_physics,
         const NumericalFlux::NumericalFluxConvective<dim, nspecies, nstate, adtype>  &conv_num_flux,
         const NumericalFlux::NumericalFluxDissipative<dim, nspecies, nstate, adtype> &diss_num_flux,
         std::vector<adtype>                                                  &local_rhs_int_cell,
@@ -1147,73 +1155,75 @@ class EntropyStable_viscousBR2
     private:
     /// Projects tensor values at the volume quadrature to obtain a polynomial and interpolates that polynomial to the face quadratures.
     template <typename adtype>
-    void interpolate_to_face(
+    static void interpolate_to_face(
         std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_vol,
         OPERATOR::basis_functions<dim,2*dim> &flux_basis,
         const unsigned int n_face_quad_pts,
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face) const;
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &T_at_face);
 
     /// Evaluates integral of a tensor at the face
     template <typename adtype>
-    void evaluate_face_integral(
+    static void evaluate_face_integral(
         std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<std::vector<adtype>,nstate> &sigma_dot_n_at_face,
         const std::vector<adtype> &JxW_face,
         OPERATOR::basis_functions<dim,2*dim> &soln_basis,
         const unsigned int n_dofs_cell,
-        std::vector<adtype> &integral_val) const;
+        std::vector<adtype> &integral_val);
 
     /// Computes polynomial based on the values at the face
     template <typename adtype>
-    void compute_lift_polynomial(
+    static void compute_lift_polynomial(
         std::vector<bool> face_orientation,
         const unsigned int iface,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &phi_at_face,
         const std::vector<adtype> &JxW_face,
         const std::vector<adtype> &JxW_vol,
         OPERATOR::basis_functions<dim,2*dim> &flux_basis,
+        const unsigned int n_face_quad_pts,
         const unsigned int n_vol_quad_pts,
         const bool is_interior_face,
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol) const;
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &re_out_vol);
 
     /// Computes physical gradient of the entropy variable
     template <typename adtype>
-    void compute_physical_grad_entropy_var(
+    static void compute_physical_grad_entropy_var(
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
         const unsigned int                                                 n_quad_pts,
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad) const;
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>       &entropy_var_phys_grad);
 
     /// Applies diffusion matrix entropy based (referred to as K in Jesse Chan's paper).
     template <typename adtype>
-    void apply_diffusion_matrix_entropy_based(
+    static void apply_diffusion_matrix_entropy_based(
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
         const unsigned int                                                 n_quad_pts,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_in,
-        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out) const;
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>         &T_out);
 
     
     /// Computes the volume integral of gradient of basis times diffusion matrix times input tensor
     template <typename adtype>
-    void compute_gradbasis_diffusionmatrix_times_input_vol_integral(
+    static void compute_gradbasis_diffusionmatrix_times_input_vol_integral(
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_quads,
         const unsigned int                                                 n_quad_pts,
         const unsigned int                                                 n_dofs_cell,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
         const std::vector<double>                                          &weight_vect,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>         &pde_physics,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate>   &T_input,
-        std::vector<adtype>                                                &integral_val) const;
-
+        std::vector<adtype>                                                &integral_val);
+    
+    public:
     /// Assemble BR2 volume term.
     template <typename adtype>
-    void assemble_volume_term_entropystable_br2(
+    static void assemble_volume_term_entropystable_br2(
         const unsigned int                                                 poly_degree,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_coeff,
         const std::array<std::vector<adtype>,nstate>                       &entropy_var_at_q,
@@ -1221,12 +1231,13 @@ class EntropyStable_viscousBR2
         const unsigned int                                                  n_dofs_cell,
         OPERATOR::basis_functions<dim,2*dim>                               &soln_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
-        std::vector<adtype>                                                &vol_term) const;
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>         &pde_physics,
+        const std::vector<double>                                          &weight_vect,
+        std::vector<adtype>                                                &vol_term);
 
     /// Assemble BR2 face term.
     template <typename adtype>
-    void assemble_face_term_entropystable_br2(
+    static void assemble_face_term_entropystable_br2(
         std::vector<bool>                                                  face_orientation_int,
         std::vector<bool>                                                  face_orientation_ext,
         const unsigned int                                                 iface_int,
@@ -1252,13 +1263,15 @@ class EntropyStable_viscousBR2
         OPERATOR::basis_functions<dim,2*dim>                               &flux_basis_ext,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_int,
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper_ext,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
+        const std::vector<double>                                          &vol_quad_weights_int,
+        const std::vector<double>                                          &vol_quad_weights_ext,
         std::vector<adtype>                                                &face_term_int,
-        std::vector<adtype>                                                &face_term_ext) const;
+        std::vector<adtype>                                                &face_term_ext);
 
     /// Assemble BR2 boundary term.
     template <typename adtype>
-    void assemble_boundary_term_entropystable_br2(
+    static void assemble_boundary_term_entropystable_br2(
         std::vector<bool>                                                  face_orientation,
         const unsigned int                                                 iface,
         const unsigned int                                                 boundary_id,
@@ -1274,8 +1287,9 @@ class EntropyStable_viscousBR2
         OPERATOR::metric_operators<adtype,dim,2*dim>                       &metric_oper,
         const std::vector<dealii::Tensor<1,dim,adtype>>                    &unit_phys_normal,
         const std::vector<adtype>                                          &JxW_face,
-        const Physics::PhysicsBase<dim, nstate, adtype>                    &pde_physics,
-        std::vector<adtype>                                                &boundary_term) const;
+        const Physics::PhysicsBase<dim, nspecies, nstate, adtype>          &pde_physics,
+        const std::vector<double>                                          &vol_quad_weights,
+        std::vector<adtype>                                                &boundary_term);
 };
 
 } // PHiLiP namespace

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -894,9 +894,22 @@ protected:
         const std::array<std::vector<adtype>,nstate> &soln_at_q,
         const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_q);
     
-    /// Compute filtered solution at the face
+    /// Compute filtered solution at the face and volume
     template <typename adtype>
-    void compute_filtered_solution_volume_and_face()
+    void compute_filtered_solution_volume_and_face(
+        std::array<std::vector<adtype>,nstate> &legendre_soln_at_vol_q,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_vol_q,
+        std::array<std::vector<adtype>,nstate> &legendre_soln_at_surf_q,
+        std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &legendre_aux_soln_at_surf_q,
+        const std::array<std::vector<adtype>,nstate> &soln_at_vol_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_vol_q,
+        Physics::PhysicsBase<dim, nspecies, nstate, adtype>                &pde_physics,
+        const std::array<std::vector<adtype>,nstate> &soln_at_surf_q,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_at_surf_q,
+        const unsigned int n_quad_pts_vol,
+        const unsigned int n_face_quad_pts,
+        const unsigned int n_shape_fns,
+        const unsigned int poly_degree);
 
 protected:
     /// Strong form primary equation's volume right-hand-side.

--- a/src/dg/strong_dg.hpp
+++ b/src/dg/strong_dg.hpp
@@ -851,11 +851,17 @@ protected:
     template <typename adtype>
     void assemble_volume_term_viscous_primal(
         const std::array<std::vector<adtype>,nstate>  &soln_coeff,
+        const std::array<dealii::Tensor<1,dim,std::vector<adtype>>,nstate> &aux_soln_coeff,
         const unsigned int                            poly_degree,
         OPERATOR::basis_functions<dim,2*dim>          &soln_basis,
         OPERATOR::basis_functions<dim,2*dim>          &flux_basis,
         OPERATOR::metric_operators<adtype,dim,2*dim>  &metric_oper,
-        dealii::Tensor<1,dim,std::vector<adtype>>     &local_auxiliary_RHS);
+        const std::array<std::vector<adtype>,nstate>  &entropy_var_coeff,
+        const std::array<std::vector<adtype>,nstate>  &entropy_var_at_q,
+        const unsigned int  n_quad_pts,
+        const unsigned int  n_dofs_cell,
+        const Physics::PhysicsBase<dim, nstate, adtype> &pde_physics,
+        std::vector<adtype>     &vol_term_viscous) const;
     
     ///Evaluate the boundary RHS for viscous term.
     template <typename adtype>

--- a/src/operators/operators.cpp
+++ b/src/operators/operators.cpp
@@ -439,7 +439,6 @@ void SumFactorizedOperators<dim,n_faces>::matrix_vector_mult_surface_1D(
     }
 }
 
-
 template <int dim, int n_faces>  
 template <typename real>
 void SumFactorizedOperators<dim,n_faces>::inner_product_surface_1D(
@@ -453,8 +452,6 @@ void SumFactorizedOperators<dim,n_faces>::inner_product_surface_1D(
     const bool adding,
     const double factor)
 {
-    
-
     std::vector<real> input_vect_corrected;
     if(!face_orientation[0] || face_orientation[1] || face_orientation[2]){
         this->face_orientation_inner_product(face_orientation, face_number, input_vect, input_vect_corrected, basis_vol);
@@ -474,6 +471,40 @@ void SumFactorizedOperators<dim,n_faces>::inner_product_surface_1D(
         this->inner_product(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_vol, basis_surf[0], adding, factor);
     if(face_number == 5)
         this->inner_product(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_vol, basis_surf[1], adding, factor);
+}
+
+template <int dim, int n_faces>  
+template <typename real>
+void SumFactorizedOperators<dim,n_faces>::inner_product_surface_1D_JxW(
+    const std::vector<bool> face_orientation,
+    const unsigned int face_number,
+    const std::vector<real> &input_vect,
+    const std::vector<real> &weight_vect,
+    std::vector<real> &output_vect,
+    const std::array<dealii::FullMatrix<double>,2> &basis_surf,
+    const dealii::FullMatrix<double> &basis_vol,
+    const bool adding,
+    const double factor)
+{
+    std::vector<real> input_vect_corrected;
+    if(!face_orientation[0] || face_orientation[1] || face_orientation[2]){
+        this->face_orientation_inner_product(face_orientation, face_number, input_vect, input_vect_corrected, basis_vol);
+    }else{
+        input_vect_corrected = input_vect;
+    }
+
+    if(face_number == 0)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_surf[0], basis_vol, basis_vol, adding, factor);
+    if(face_number == 1)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_surf[1], basis_vol, basis_vol, adding, factor);
+    if(face_number == 2)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_surf[0], basis_vol, adding, factor);
+    if(face_number == 3)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_surf[1], basis_vol, adding, factor);
+    if(face_number == 4)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_vol, basis_surf[0], adding, factor);
+    if(face_number == 5)
+        this->inner_product_JxW(input_vect_corrected, weight_vect, output_vect, basis_vol, basis_vol, basis_surf[1], adding, factor);
 }
 
 template <int dim, int n_faces>  
@@ -646,6 +677,84 @@ void SumFactorizedOperators<dim,n_faces>::inner_product_1D(
     const double factor) 
 {
     this->inner_product(input_vect, weight_vect, output_vect, basis_x, basis_x, basis_x, adding, factor);
+}
+
+template <int dim, int n_faces>  
+template <typename real>
+void SumFactorizedOperators<dim,n_faces>::inner_product_JxW(
+    const std::vector<real> &input_vect,
+    const std::vector<real> &weight_vect,
+    std::vector<real> &output_vect,
+    const dealii::FullMatrix<double> &basis_x,
+    const dealii::FullMatrix<double> &basis_y,
+    const dealii::FullMatrix<double> &basis_z,
+    const bool adding,
+    const double factor) 
+{
+    //assert that each basis matrix is of size (rows x columns)
+    const unsigned int rows_x    = basis_x.m();
+    const unsigned int rows_y    = basis_y.m();
+    const unsigned int rows_z    = basis_z.m();
+    const unsigned int columns_x = basis_x.n();
+    const unsigned int columns_y = basis_y.n();
+    const unsigned int columns_z = basis_z.n();
+    //Note the assertion has columns to output and rows to input
+    //bc we transpose the basis inputted for the inner product
+    if constexpr (dim == 1){
+        assert(rows_x    == input_vect.size());
+        assert(columns_x == output_vect.size());
+    }
+    if constexpr (dim == 2){
+        assert(rows_x * rows_y       == input_vect.size());
+        assert(columns_x * columns_y == output_vect.size());
+    }
+    if constexpr (dim == 3){
+        assert(rows_x * rows_y * rows_z          == input_vect.size());
+        assert(columns_x * columns_y * columns_z == output_vect.size());
+    }
+    assert(weight_vect.size() == input_vect.size()); 
+
+    dealii::FullMatrix<double> basis_x_trans(columns_x, rows_x);
+    dealii::FullMatrix<double> basis_y_trans(columns_y, rows_y);
+    dealii::FullMatrix<double> basis_z_trans(columns_z, rows_z);
+
+    //set as the transpose as inputed basis
+    //found an issue with Tadd for arbitrary size so I manually do it here.
+    for(unsigned int row=0; row<rows_x; row++){
+        for(unsigned int col=0; col<columns_x; col++){
+            basis_x_trans[col][row] = basis_x[row][col];
+        }
+    }
+    for(unsigned int row=0; row<rows_y; row++){
+        for(unsigned int col=0; col<columns_y; col++){
+            basis_y_trans[col][row] = basis_y[row][col];
+        }
+    }
+    for(unsigned int row=0; row<rows_z; row++){
+        for(unsigned int col=0; col<columns_z; col++){
+            basis_z_trans[col][row] = basis_z[row][col];
+        }
+    }
+
+    std::vector<real> new_input_vect(input_vect.size());
+    for(unsigned int iquad=0; iquad<input_vect.size(); iquad++){
+        new_input_vect[iquad] = input_vect[iquad] * weight_vect[iquad];
+    }
+
+    this->matrix_vector_mult(new_input_vect, output_vect, basis_x_trans, basis_y_trans, basis_z_trans, adding, factor);
+}
+
+template <int dim, int n_faces>  
+template <typename real>
+void SumFactorizedOperators<dim,n_faces>::inner_product_1D_JxW(
+    const std::vector<real> &input_vect,
+    const std::vector<real> &weight_vect,
+    std::vector<real> &output_vect,
+    const dealii::FullMatrix<double> &basis_x,
+    const bool adding,
+    const double factor) 
+{
+    this->inner_product_JxW(input_vect, weight_vect, output_vect, basis_x, basis_x, basis_x, adding, factor);
 }
 
 template <int dim, int n_faces>  
@@ -2398,6 +2507,30 @@ void metric_operators<real,dim,n_faces>::transform_physical_to_reference_vector(
 
 }
 
+template <typename real, int dim, int n_faces>
+void metric_operators<real,dim,n_faces>::transform_reference_to_physical_grad_vector(
+    const dealii::Tensor<1,dim,std::vector<real>> &ref,
+    const dealii::Tensor<2,dim,std::vector<real>> &metric_cofactor,
+    const std::vector<real> &jac_det,
+    dealii::Tensor<1,dim,std::vector<real>> &phys)
+{
+    assert(ref[0].size() == metric_cofactor[0][0].size());
+    const unsigned int n_quad_pts = ref[0].size();
+
+    for(int idim=0; idim<dim; idim++)
+    {
+        phys[idim].resize(n_quad_pts); // set to 0 by default.
+        for(unsigned int iquad=0; iquad<n_quad_pts; ++iquad)
+        {
+            for(int idim2=0; idim2<dim; idim2++)
+            {
+                phys[idim][iquad] += metric_cofactor[idim][idim2][iquad] * ref[idim2][iquad]/jac_det[iquad];
+            }
+
+        }
+    }
+}
+
 template <typename real, int dim, int n_faces>  
 void metric_operators<real,dim,n_faces>::transform_reference_unit_normal_to_physical_unit_normal(
     const unsigned int n_quad_pts,
@@ -3390,6 +3523,52 @@ template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product<Rad
             const bool adding = false,
             const double factor = 1.0);
 
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_JxW<double>(
+            const std::vector<double> &input_vect,
+            const std::vector<double> &weight_vect,
+            std::vector<double> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_JxW<FadType>(
+            const std::vector<FadType> &input_vect,
+            const std::vector<FadType> &weight_vect,
+            std::vector<FadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_JxW<RadType>(
+            const std::vector<RadType> &input_vect,
+            const std::vector<RadType> &weight_vect,
+            std::vector<RadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_JxW<FadFadType>(
+            const std::vector<FadFadType> &input_vect,
+            const std::vector<FadFadType> &weight_vect,
+            std::vector<FadFadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_JxW<RadFadType>(
+            const std::vector<RadFadType> &input_vect,
+            const std::vector<RadFadType> &weight_vect,
+            std::vector<RadFadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
+
 template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::matrix_vector_mult_1D<double>(
             const std::vector<double> &input_vect,
             std::vector<double> &output_vect,
@@ -3452,6 +3631,42 @@ template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D<
 template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D<RadFadType>(
             const std::vector<RadFadType> &input_vect,
             const std::vector<double> &weight_vect,
+            std::vector<RadFadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
+
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D_JxW<double>(
+            const std::vector<double> &input_vect,
+            const std::vector<double> &weight_vect,
+            std::vector<double> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D_JxW<FadType>(
+            const std::vector<FadType> &input_vect,
+            const std::vector<FadType> &weight_vect,
+            std::vector<FadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D_JxW<RadType>(
+            const std::vector<RadType> &input_vect,
+            const std::vector<RadType> &weight_vect,
+            std::vector<RadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D_JxW<FadFadType>(
+            const std::vector<FadFadType> &input_vect,
+            const std::vector<FadFadType> &weight_vect,
+            std::vector<FadFadType> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_1D_JxW<RadFadType>(
+            const std::vector<RadFadType> &input_vect,
+            const std::vector<RadFadType> &weight_vect,
             std::vector<RadFadType> &output_vect,
             const dealii::FullMatrix<double> &basis_x,
             const bool adding  = false,
@@ -3549,6 +3764,57 @@ template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_sur
             const unsigned int face_number,
             const std::vector<RadFadType> &input_vect,
             const std::vector<double> &weight_vect,
+            std::vector<      RadFadType> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_surface_1D_JxW<double>(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<double> &input_vect,
+            const std::vector<double> &weight_vect,
+            std::vector<      double> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_surface_1D_JxW<FadType>(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<FadType> &input_vect,
+            const std::vector<FadType> &weight_vect,
+            std::vector<      FadType> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_surface_1D_JxW<RadType>(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<RadType> &input_vect,
+            const std::vector<RadType> &weight_vect,
+            std::vector<      RadType> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_surface_1D_JxW<FadFadType>(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<FadFadType> &input_vect,
+            const std::vector<FadFadType> &weight_vect,
+            std::vector<      FadFadType> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+template void SumFactorizedOperators<PHILIP_DIM,2*PHILIP_DIM>::inner_product_surface_1D_JxW<RadFadType>(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<RadFadType> &input_vect,
+            const std::vector<RadFadType> &weight_vect,
             std::vector<      RadFadType> &output_vect,
             const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
             const dealii::FullMatrix<double> &basis_vol,

--- a/src/operators/operators.h
+++ b/src/operators/operators.h
@@ -199,7 +199,7 @@ public:
     
     /// Inner product function that takes in an ADtype for the weights
     template <typename real>
-    void inner_product(
+    void inner_product_JxW(
             const std::vector<real> &input_vect,
             const std::vector<real> &weight_vect,
             std::vector<real> &output_vect,
@@ -315,7 +315,7 @@ public:
     
     /// Apply the inner product operation using the 1D operator in each direction. Takes in Adtype for the weights.
     template <typename real>
-    void inner_product_1D(
+    void inner_product_1D_JxW(
             const std::vector<real> &input_vect,
             const std::vector<real> &weight_vect,
             std::vector<real> &output_vect,
@@ -356,7 +356,7 @@ public:
     
     /// Apply sum-factorization inner product on a surface. Takes in Adtype for the weights.
     template <typename real>
-    void inner_product_surface_1D(
+    void inner_product_surface_1D_JxW(
             const std::vector<bool> face_orientation,
             const unsigned int face_number,
             const std::vector<real> &input_vect,

--- a/src/operators/operators.h
+++ b/src/operators/operators.h
@@ -196,6 +196,18 @@ public:
             const dealii::FullMatrix<double> &basis_z,
             const bool adding = false,
             const double factor = 1.0);
+    
+    /// Inner product function that takes in an ADtype for the weights
+    template <typename real>
+    void inner_product(
+            const std::vector<real> &input_vect,
+            const std::vector<real> &weight_vect,
+            std::vector<real> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const dealii::FullMatrix<double> &basis_y,
+            const dealii::FullMatrix<double> &basis_z,
+            const bool adding = false,
+            const double factor = 1.0);
 
 
     ///Computes the divergence of the 2pt flux Hadamard products, then sums the rows.
@@ -300,6 +312,16 @@ public:
             const dealii::FullMatrix<double> &basis_x,
             const bool adding  = false,
             const double factor = 1.0);
+    
+    /// Apply the inner product operation using the 1D operator in each direction. Takes in Adtype for the weights.
+    template <typename real>
+    void inner_product_1D(
+            const std::vector<real> &input_vect,
+            const std::vector<real> &weight_vect,
+            std::vector<real> &output_vect,
+            const dealii::FullMatrix<double> &basis_x,
+            const bool adding  = false,
+            const double factor = 1.0);
 
     /// Apply sum-factorization matrix vector multiplication on a surface.
     /** Often times we have to interpolate to a surface, where in multiple dimensions,
@@ -326,6 +348,19 @@ public:
             const unsigned int face_number,
             const std::vector<real> &input_vect,
             const std::vector<double> &weight_vect,
+            std::vector<real> &output_vect,
+            const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
+            const dealii::FullMatrix<double> &basis_vol,
+            const bool adding = false,
+            const double factor = 1.0);
+    
+    /// Apply sum-factorization inner product on a surface. Takes in Adtype for the weights.
+    template <typename real>
+    void inner_product_surface_1D(
+            const std::vector<bool> face_orientation,
+            const unsigned int face_number,
+            const std::vector<real> &input_vect,
+            const std::vector<real> &weight_vect,
             std::vector<real> &output_vect,
             const std::array<dealii::FullMatrix<double>,2> &basis_surf,//only 2 faces in 1D
             const dealii::FullMatrix<double> &basis_vol,
@@ -1166,6 +1201,13 @@ public:
         const dealii::Tensor<1,dim,std::vector<real>> &phys,
         const dealii::Tensor<2,dim,std::vector<real>> &metric_cofactor,
         dealii::Tensor<1,dim,std::vector<real>> &ref);
+
+    /// Transform reference gradient to physical gradient.
+    void transform_reference_to_physical_grad_vector(
+        const dealii::Tensor<1,dim,std::vector<real>> &ref,
+        const dealii::Tensor<2,dim,std::vector<real>> &metric_cofactor,
+        const std::vector<real> &jac_det,
+        dealii::Tensor<1,dim,std::vector<real>> &phys);
 
     ///Given a reference tensor, return the physical tensor.
     void transform_reference_unit_normal_to_physical_unit_normal(

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -161,6 +161,10 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       dealii::Patterns::Bool(),
                       "Check validty of metric Jacobian when high-order grid is constructed by default. Do not check if false. Not checking is useful if the metric terms are built on the fly with operators, it reduces the memory cost for high polynomial grids. The metric Jacobian is never checked for strong form, regardless of the user input.");
 
+    prm.declare_entry("use_viscous_br2_entropystable", "false",
+                      dealii::Patterns::Bool(),
+                      "Use entropy stable BR2 discretization of the viscous terms.");
+    
     prm.declare_entry("energy_file", "energy_file",
                       dealii::Patterns::FileName(dealii::Patterns::FileName::FileType::input),
                       "Input file for energy test.");
@@ -594,8 +598,14 @@ const std::string test_string = prm.get("test_type");
     use_invariant_curl_form = prm.get_bool("use_invariant_curl_form");
     use_inverse_mass_on_the_fly = prm.get_bool("use_inverse_mass_on_the_fly");
     check_valid_metric_Jacobian = prm.get_bool("check_valid_metric_Jacobian");
+    use_viscous_br2_entropystable = prm.get_bool("use_viscous_br2_entropystable");
     if(!use_weak_form){
         check_valid_metric_Jacobian = false;
+    }
+    if(use_weak_form && use_viscous_br2_entropystable)
+    {
+        std::cout<<"Viscous entropy stable BR2 is not implemented for Weak DG. Aborting..."<<std::endl;
+        std::abort();
     }
 
     energy_file = prm.get("energy_file");

--- a/src/parameters/all_parameters.cpp
+++ b/src/parameters/all_parameters.cpp
@@ -192,6 +192,7 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       " euler_naca_optimization | "
                       " shock_1d | "
                       " euler_naca0012 | "
+                      " lid_driven_cavity | "
                       " reduced_order | "
                       " unsteady_reduced_order |"
                       " convection_diffusion_periodicity |"
@@ -249,6 +250,7 @@ void AllParameters::declare_parameters (dealii::ParameterHandler &prm)
                       "  euler_naca_optimization | "
                       "  shock_1d | "
                       "  euler_naca0012 | "
+                      "  lid_driven_cavity | "
                       "  convection_diffusion_periodicity |"
                       "  reduced_order | "
                       "  unsteady_reduced_order | "
@@ -474,6 +476,7 @@ const std::string test_string = prm.get("test_type");
     else if (test_string == "adaptive_sampling_testing")                { test_type = adaptive_sampling_testing; }
     else if (test_string == "finite_difference_sensitivity")            { test_type = finite_difference_sensitivity; }
     else if (test_string == "euler_naca0012")                           { test_type = euler_naca0012; }
+    else if (test_string == "lid_driven_cavity")                        { test_type = lid_driven_cavity; }
     else if (test_string == "optimization_inverse_manufactured")        { test_type = optimization_inverse_manufactured; }
     else if (test_string == "dual_weighted_residual_mesh_adaptation")   { test_type = dual_weighted_residual_mesh_adaptation; }
     else if (test_string == "anisotropic_mesh_adaptation")              { test_type = anisotropic_mesh_adaptation; }

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -191,6 +191,7 @@ public:
         euler_naca_optimization,
         shock_1d,
         euler_naca0012,
+        lid_driven_cavity,
         reduced_order,
         unsteady_reduced_order,
         convection_diffusion_periodicity,

--- a/src/parameters/all_parameters.h
+++ b/src/parameters/all_parameters.h
@@ -157,6 +157,9 @@ public:
 
     /// Flag to check if the metric Jacobian is valid when high-order grid is constructed.
     bool check_valid_metric_Jacobian;
+    
+    /// Flag to use entropy stable viscous BR2.
+    bool use_viscous_br2_entropystable;
 
     /// Energy file.
     std::string energy_file;

--- a/src/physics/euler.cpp
+++ b/src/physics/euler.cpp
@@ -1574,7 +1574,14 @@ void Euler<dim,nspecies,nstate,real>
     else if (boundary_type == 1010)
     {
         // Moving wall BC
-        // Do nothing here. It is implemented in NavierStokes::boundary_face_values_entropy_var().
+        // Note: Convective flux uses the same BC as solid slip wall. The dissipative flux uses a different BC to account for the moving wall.
+        // With this boundary_type, a different BC is used in NavierStokes::boundary_face_values_entropy_var() for the viscous terms. 
+        boundary_wall (normal_int, soln_int, soln_grad_int, soln_bc, soln_grad_bc);
+        if(! this->all_parameters->use_viscous_br2_entropystable)
+        {
+            std::cout<<"Boundary type 1010 is only implemented for use_viscous_br2_entropystable = true. Aborting..."<<std::endl;
+            std::abort();
+        }
     }
     else {
         this->pcout << "Invalid boundary_type: " << boundary_type << std::endl;

--- a/src/physics/euler.cpp
+++ b/src/physics/euler.cpp
@@ -1571,6 +1571,11 @@ void Euler<dim,nspecies,nstate,real>
         // Boundary specific to the the astrophysical jet case
         boundary_astrophysical_inflow (soln_bc);
     }
+    else if (boundary_type == 1010)
+    {
+        // Moving wall BC
+        // Do nothing here. It is implemented in NavierStokes::boundary_face_values_entropy_var().
+    }
     else {
         this->pcout << "Invalid boundary_type: " << boundary_type << std::endl;
         std::abort();

--- a/src/physics/navier_stokes.cpp
+++ b/src/physics/navier_stokes.cpp
@@ -906,14 +906,14 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,r
     return viscous_flux;
 }
 
-template <int dim, int nstate, typename real>
-std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+template <int dim, int nspecies, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,real>
 ::dissipative_flux_entropy_based (
     const std::array<real,nstate> &entropy_var,
     const std::array<dealii::Tensor<1,dim,real>,nstate> &entropy_var_gradient) const
 {
     const std::array<real,nstate> conservative_soln_from_entropy_var = this->compute_conservative_variables_from_entropy_variables (entropy_var);
-    const std::array<real,nstate> primitive_soln = this->template convert_conservative_to_primitive<real>(conservative_soln_from_entropy_var);
+    const std::array<real,nstate> primitive_soln = this->template convert_conservative_to_primitive_templated<real>(conservative_soln_from_entropy_var);
     const real mu = compute_scaled_viscosity_coefficient<real>(primitive_soln); // \mu
     const real lambda = (-2.0/3.0)*mu; // \lambda from Stokes' hypothesis
     std::array<std::array<dealii::Tensor<2,dim,real>,nstate>,nstate> K;  // entropy-based diffusion tensor. Defaults to zero. Indexed as K[s1][s2][d1][d2].
@@ -1096,8 +1096,8 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
 }
 
 
-template <int dim, int nstate, typename real>
-std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+template <int dim, int nspecies, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,real>
 ::apply_d_entropy_var_d_conservative_var(
     const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
     const std::array<real,nstate> & entropy_var) const
@@ -1219,8 +1219,8 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
 }
 
 
-template <int dim, int nstate, typename real>
-std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+template <int dim, int nspecies, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,real>
 ::apply_d_conservative_var_d_entropy_var(
     const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
     const std::array<real,nstate> & entropy_var) const
@@ -1350,8 +1350,8 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
     return out_vector;
 }
 
-template <int dim, int nstate, typename real>
-void NavierStokes<dim,nstate,real>
+template <int dim, int nspecies, int nstate, typename real>
+void NavierStokes<dim,nspecies,nstate,real>
 ::boundary_face_values_entropy_var(
     const dealii::Point<dim,real> &pos,
     const std::array<real,nstate> & v_int_at_q,

--- a/src/physics/navier_stokes.cpp
+++ b/src/physics/navier_stokes.cpp
@@ -920,6 +920,7 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,r
 
     if constexpr(dim==3)
     {
+        // Equations from Hughes, Thomas JR, Leopaldo P. Franca, and Michel Mallet. "A new finite element formulation for computational fluid dynamics: I. Symmetric forms of the compressible Euler and Navier-Stokes equations and the second law of thermodynamics." Computer methods in applied mechanics and engineering 54.2 (1986): 223-234.
         //const real v1 = entropy_var[0];
         const real v2 = entropy_var[1];
         const real v3 = entropy_var[2];
@@ -1015,6 +1016,7 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,r
     }
     else if constexpr(dim==2)
     {
+        // Expressions from Chan, Jesse, Yimin Lin, and Tim Warburton. "Entropy stable modal discontinuous Galerkin schemes and wall boundary conditions for the compressible Navier-Stokes equations." Journal of Computational Physics 448 (2022).
         //const real v1 = entropy_var[0];
         const real v2 = entropy_var[1];
         const real v3 = entropy_var[2];
@@ -1106,6 +1108,7 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,r
     std::array<std::array<real,nstate>,nstate> dVdU;
     if constexpr(dim==3)
     {
+        // Equations from Hughes, Thomas JR, Leopaldo P. Franca, and Michel Mallet. "A new finite element formulation for computational fluid dynamics: I. Symmetric forms of the compressible Euler and Navier-Stokes equations and the second law of thermodynamics." Computer methods in applied mechanics and engineering 54.2 (1986): 223-234.
         const real v1 = entropy_var[0];
         const real v2 = entropy_var[1];
         const real v3 = entropy_var[2];
@@ -1363,6 +1366,7 @@ void NavierStokes<dim,nspecies,nstate,real>
     const unsigned int boundary_id) const
 {
     // Note: Computes v_bc as the actual entropy var at the boundary.
+    // Entropy stable BCs adapted from Chan, Jesse, Yimin Lin, and Tim Warburton. "Entropy stable modal discontinuous Galerkin schemes and wall boundary conditions for the compressible Navier-Stokes equations." Journal of Computational Physics 448 (2022): 110723.
     if(boundary_id==1001)//Adiabatic wall boundary zero velocity
     {
         for(unsigned int s=0; s<nstate-1; ++s)

--- a/src/physics/navier_stokes.cpp
+++ b/src/physics/navier_stokes.cpp
@@ -906,6 +906,559 @@ std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nspecies,nstate,r
     return viscous_flux;
 }
 
+template <int dim, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+::dissipative_flux_entropy_based (
+    const std::array<real,nstate> &entropy_var,
+    const std::array<dealii::Tensor<1,dim,real>,nstate> &entropy_var_gradient) const
+{
+    const std::array<real,nstate> conservative_soln_from_entropy_var = this->compute_conservative_variables_from_entropy_variables (entropy_var);
+    const std::array<real,nstate> primitive_soln = this->template convert_conservative_to_primitive<real>(conservative_soln_from_entropy_var);
+    const real mu = compute_scaled_viscosity_coefficient<real>(primitive_soln); // \mu
+    const real lambda = (-2.0/3.0)*mu; // \lambda from Stokes' hypothesis
+    std::array<std::array<dealii::Tensor<2,dim,real>,nstate>,nstate> K;  // entropy-based diffusion tensor. Defaults to zero. Indexed as K[s1][s2][d1][d2].
+
+    if constexpr(dim==3)
+    {
+        //const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        const real v5 = entropy_var[4];
+        const real e1 = v2*v5;
+        const real e2 = v3*v5;
+        const real e3 = v4*v5;
+        const real d1 = -v2*v3;
+        const real d2 = -v2*v4;
+        const real d3 = -v3*v4;
+
+        // K11
+        K[1][1][0][0] = -(lambda+2.0*mu)*pow(v5,2);
+        K[4][1][0][0] = (lambda+2.0*mu)*e1;
+
+
+        K[2][2][0][0] = -mu*pow(v5,2);
+        K[4][2][0][0] = mu*e2;
+
+
+        K[3][3][0][0] = -mu*pow(v5,2);
+        K[4][3][0][0] = mu*e3;
+
+
+        K[1][4][0][0] = (lambda+2.0*mu)*e1;
+        K[2][4][0][0] = mu*e2;
+        K[3][4][0][0] = mu*e3;
+        K[4][4][0][0] = -(  (lambda+2.0*mu)*pow(v2,2) + mu*(pow(v3,2)+pow(v4,2))
+                            - this->gam*mu*v5/prandtl_number);
+
+        // K12
+        K[2][1][0][1] = -mu*pow(v5,2);
+        K[4][1][0][1] = mu*e2;
+        K[1][2][0][1] = -lambda*pow(v5,2);
+        K[4][2][0][1] = lambda*e1;
+        K[1][4][0][1] = lambda*e2;
+        K[2][4][0][1] = mu*e1;
+        K[4][4][0][1] = (lambda+mu)*d1;
+
+        // K13
+        K[3][1][0][2] = -mu*pow(v5,2);
+        K[4][1][0][2] = mu*e3;
+        K[1][3][0][2] = -lambda*pow(v5,2);
+        K[4][3][0][2] = lambda*e1;
+        K[1][4][0][2] = lambda*e3;
+        K[3][4][0][2] = mu*e1;
+        K[4][4][0][2] = (lambda+mu)*d2;
+
+
+        // K22
+        K[1][1][1][1] = -mu*pow(v5,2);
+        K[4][1][1][1] = mu*e1;
+        K[2][2][1][1] = -(lambda + 2.0*mu)*pow(v5,2);
+        K[4][2][1][1] = (lambda+2.0*mu)*e2;
+        K[3][3][1][1] = -mu*pow(v5,2);
+        K[4][3][1][1] = mu*e3;
+        K[1][4][1][1] = mu*e1;
+        K[2][4][1][1] = (lambda+2.0*mu)*e2;
+        K[3][4][1][1] = mu*e3;
+        K[4][4][1][1] = -(  (lambda+2.0*mu)*pow(v3,2) + mu*(pow(v2,2)+pow(v4,2))
+                            - this->gam*mu*v5/prandtl_number   );
+
+
+        // K23
+        K[3][2][1][2] = -mu*pow(v5,2);
+        K[4][2][1][2] = mu*e3;
+        K[2][3][1][2] = -lambda*pow(v5,2);
+        K[4][3][1][2] = lambda*e2;
+        K[2][4][1][2] = lambda*e3;
+        K[3][4][1][2] = mu*e2;
+        K[4][4][1][2] = (lambda+mu)*d3;
+
+        // K33
+        K[1][1][2][2] = -mu*pow(v5,2);
+        K[4][1][2][2] = mu*e1;
+        K[2][2][2][2] = -mu*pow(v5,2);
+        K[4][2][2][2] = mu*e2;
+        K[3][3][2][2] = -(lambda+2.0*mu)*pow(v5,2);
+        K[4][3][2][2] = (lambda+2.0*mu)*e3;
+        K[1][4][2][2] = mu*e1;
+        K[2][4][2][2] = mu*e2;
+        K[3][4][2][2] = (lambda+2.0*mu)*e3;
+        K[4][4][2][2] =  -(  (lambda+2.0*mu)*pow(v4,2) + mu*(pow(v2,2)+pow(v3,2))
+                            - this->gam*mu*v5/prandtl_number   );
+        for(unsigned int s1 = 0; s1<nstate; ++s1)
+        {
+            for(unsigned int s2 = 0; s2<nstate; ++s2)
+            {
+                K[s1][s2] /= pow(v5,3);
+            }
+        }
+    }
+    else if constexpr(dim==2)
+    {
+        //const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        // K11
+        K[1][1][0][0] = -(lambda+2.0*mu)*pow(v4,2);
+        K[3][1][0][0] = (lambda + 2.0*mu)*v2*v4;
+        K[2][2][0][0] = -mu*pow(v4,2);
+        K[3][2][0][0] = mu*v3*v4;
+        K[1][3][0][0] = (lambda + 2.0*mu)*v2*v4;
+        K[2][3][0][0] = mu*v3*v4;
+        K[3][3][0][0] = -( (lambda+2.0*mu)*pow(v2,2) + mu*pow(v3,2) - this->gam*mu*v4/prandtl_number );
+
+        // K12
+        K[2][1][0][1] = -mu*pow(v4,2);
+        K[3][1][0][1] = mu*v3*v4;
+        K[1][2][0][1] = -lambda*pow(v4,2);
+        K[3][2][0][1] = lambda*v2*v4;
+        K[1][3][0][1] = lambda*v3*v4;
+        K[2][3][0][1] = mu*v2*v4;
+        K[3][3][0][1] = (lambda+mu)*(-v2*v3);
+
+        // K22
+        K[1][1][1][1] = -mu*pow(v4,2);
+        K[3][1][1][1] = mu*v2*v4;
+        K[2][2][1][1] = -(lambda+2.0*mu)*pow(v4,2);
+        K[3][2][1][1] = (lambda+2.0*mu)*v3*v4;
+        K[1][3][1][1] = mu*v2*v4;
+        K[2][3][1][1] = (lambda+2.0*mu)*v3*v4;
+        K[3][3][1][1] =  -( (lambda+2.0*mu)*pow(v3,2) + mu*pow(v2,2) - this->gam*mu*v4/prandtl_number );
+
+        for(unsigned int s1 = 0; s1<nstate; ++s1)
+        {
+            for(unsigned int s2 = 0; s2<nstate; ++s2)
+            {
+                K[s1][s2] /= pow(v4,3);
+            }
+        }
+    }
+    else
+    {
+        std::cout<<"Not yet implemented for dim=1: NavierStokes<dim,nstate,real>::dissipative_flux_entropy_based()"<<std::endl;
+        std::abort();
+    }
+    // Fill up remaining tensors by symmetry: K21, K31, K32
+    for(unsigned int d1 =1; d1<dim; ++d1)
+    {
+        for(unsigned int d2 =0; d2<d1; ++d2)
+        {
+            for(unsigned int s1 =0; s1<nstate; ++s1)
+            {
+                for(unsigned int s2=0; s2<nstate; ++s2)
+                {
+                    K[s1][s2][d1][d2] = K[s2][s1][d2][d1];
+                }
+            }
+        }
+    }
+
+
+    // Compute viscous flux
+    std::array<dealii::Tensor<1,dim,real>,nstate> viscous_flux; // initialized to zero by default
+    for(unsigned int d1 =0; d1<dim; ++d1)
+    {
+        for(unsigned int d2 =0; d2<dim; ++d2)
+        {
+            for(unsigned int s1 =0; s1<nstate; ++s1)
+            {
+                for(unsigned int s2=0; s2<nstate; ++s2)
+                {
+                    viscous_flux[s1][d1] += K[s1][s2][d1][d2]*entropy_var_gradient[s2][d2];
+                }
+            }
+        }
+    }
+
+    (void) lambda;
+    return viscous_flux;
+}
+
+
+template <int dim, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+::apply_d_entropy_var_d_conservative_var(
+    const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
+    const std::array<real,nstate> & entropy_var) const
+{
+
+    std::array<std::array<real,nstate>,nstate> dVdU;
+    if constexpr(dim==3)
+    {
+        const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        const real v5 = entropy_var[4];
+        const real entrops = this->gam - v1 + 0.5*(v2*v2 + v3*v3 + v4*v4)/v5;
+        const real rhoe = pow(this->gamm1/pow(-v5,this->gam),1/this->gamm1)*exp(-entrops/this->gamm1);
+
+        const real e1 = v2*v5;
+
+        const real e2 = v3*v5;
+
+        const real e3 = v4*v5;
+
+        const real k1 = 0.5*(v2*v2 + v3*v3 + v4*v4)/v5;
+
+        const real d1 = -v2*v3;
+        const real d2 = -v2*v4;
+        const real d3 = -v3*v4;
+
+
+        dVdU[0][0] = k1*k1 + this->gam; dVdU[0][1] = k1*v2; dVdU[0][2] = k1*v3; dVdU[0][3] = k1*v4; dVdU[0][4] = (k1+1)*v5;
+        dVdU[1][1] = v2*v2-v5; dVdU[1][2] = -d1; dVdU[1][3] = -d2; dVdU[1][4] = e1;
+        dVdU[2][2] = v3*v3-v5; dVdU[2][3] = -d3; dVdU[2][4] = e2;
+        dVdU[3][3] = v4*v4-v5; dVdU[3][4] = e3;
+        dVdU[4][4] = v5*v5;
+        const real factor_dVdU =  -1.0/(rhoe*v5);
+
+
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                if(i>j)
+                    dVdU[i][j] = dVdU[j][i];
+            }
+        }
+
+
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                dVdU[i][j]*=factor_dVdU;
+            }
+        }
+    }
+    else if constexpr(dim==2)
+    {
+        const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        const real entrops = this->gam - v1 + 0.5*(v2*v2 + v3*v3)/v4;
+        const real rhoe = pow(this->gamm1/pow(-v4,this->gam),1/this->gamm1)*exp(-entrops/this->gamm1);
+
+        const real e1 = v2*v4;
+
+        const real e2 = v3*v4;
+
+        const real k1 = 0.5*(v2*v2 + v3*v3)/v4;
+
+        const real d1 = -v2*v3;
+
+
+        dVdU[0][0] = k1*k1 + this->gam; dVdU[0][1] = k1*v2; dVdU[0][2] = k1*v3; dVdU[0][3] = (k1+1)*v4;
+        dVdU[1][1] = v2*v2-v4; dVdU[1][2] = -d1; dVdU[1][3] = e1;
+        dVdU[2][2] = v3*v3-v4; dVdU[2][3] = e2;
+        dVdU[3][3] = v4*v4;
+        const real factor_dVdU =  -1.0/(rhoe*v4);
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                if(i>j)
+                    dVdU[i][j] = dVdU[j][i];
+            }
+        }
+
+
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                dVdU[i][j]*=factor_dVdU;
+            }
+        }
+
+
+    }
+    else
+    {
+        std::cout<<"Not yet implemented"<<std::endl;
+        std::abort();
+    }
+
+
+        // Note: Assumes gradient is just the interior gradient. Gradient information is only used for the wall BC above.
+    std::array<dealii::Tensor<1,dim,real>,nstate> out_vector;
+    for(unsigned int i=0; i<nstate; ++i)
+    {
+        for(unsigned int j=0; j<nstate; ++j)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                out_vector[i][d] += dVdU[i][j]*in_vector[j][d];
+            }
+        }
+    }
+    return out_vector;
+}
+
+
+template <int dim, int nstate, typename real>
+std::array<dealii::Tensor<1,dim,real>,nstate> NavierStokes<dim,nstate,real>
+::apply_d_conservative_var_d_entropy_var(
+    const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
+    const std::array<real,nstate> & entropy_var) const
+{
+    std::array<std::array<real,nstate>,nstate> dUdV;
+    if constexpr(dim==3)
+    {
+        const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        const real v5 = entropy_var[4];
+        const real entrops = this->gam - v1 + 0.5*(v2*v2 + v3*v3 + v4*v4)/v5;
+        const real rhoe = pow(this->gamm1/pow(-v5,this->gam),1/this->gamm1)*exp(-entrops/this->gamm1);
+
+        const real e1 = v2*v5;
+
+        const real e2 = v3*v5;
+
+        const real e3 = v4*v5;
+
+        const real k1 = 0.5*(v2*v2 + v3*v3 + v4*v4)/v5;
+
+        const real k2 = k1-this->gam;
+
+        const real k3 = k1*k1 - 2*this->gam*k1 + this->gam;
+
+        const real c1 = this->gamm1*v5 - v2*v2;
+        const real c2 = this->gamm1*v5 - v3*v3;
+        const real c3 = this->gamm1*v5 - v4*v4;
+
+        const real d1 = -v2*v3;
+        const real d2 = -v2*v4;
+        const real d3 = -v3*v4;
+
+
+        dUdV[0][0] = -v5*v5; dUdV[0][1] = e1; dUdV[0][2] = e2; dUdV[0][3] = e3; dUdV[0][4] = v5*(1-k1);
+        dUdV[1][1] = c1; dUdV[1][2] = d1; dUdV[1][3] = d2; dUdV[1][4] = v2*k2;
+        dUdV[2][2] = c2; dUdV[2][3] = d3; dUdV[2][4] = v3*k2;
+        dUdV[3][3] = c3; dUdV[3][4] = v4*k2;
+        dUdV[4][4] = -k3;
+        const real factor_dUdV = rhoe/(this->gamm1*v5);
+
+
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                if(i>j)
+                    dUdV[i][j] = dUdV[j][i];
+            }
+        }
+
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                dUdV[i][j]*=factor_dUdV;
+            }
+        }
+
+
+    }
+    else if constexpr(dim==2)
+    {
+        const real v1 = entropy_var[0];
+        const real v2 = entropy_var[1];
+        const real v3 = entropy_var[2];
+        const real v4 = entropy_var[3];
+        const real entrops = this->gam - v1 + 0.5*(v2*v2 + v3*v3)/v4;
+        const real rhoe = pow(this->gamm1/pow(-v4,this->gam),1/this->gamm1)*exp(-entrops/this->gamm1);
+
+        const real e1 = v2*v4;
+
+        const real e2 = v3*v4;
+
+        const real k1 = 0.5*(v2*v2 + v3*v3)/v4;
+
+        const real k2 = k1-this->gam;
+
+        const real k3 = k1*k1 - 2*this->gam*k1 + this->gam;
+
+        const real c1 = this->gamm1*v4 - v2*v2;
+        const real c2 = this->gamm1*v4 - v3*v3;
+
+        const real d1 = -v2*v3;
+
+        dUdV[0][0] = -v4*v4; dUdV[0][1] = e1; dUdV[0][2] = e2; dUdV[0][3] = v4*(1-k1);
+        dUdV[1][1] = c1; dUdV[1][2] = d1; dUdV[1][3] = v2*k2;
+        dUdV[2][2] = c2; dUdV[2][3] = v3*k2;
+        dUdV[3][3] = -k3;
+        const real factor_dUdV = rhoe/(this->gamm1*v4);
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                if(i>j)
+                    dUdV[i][j] = dUdV[j][i];
+            }
+        }
+        for(unsigned int i=0; i<nstate; ++i)
+        {
+            for(unsigned j=0; j<nstate; ++j)
+            {
+                dUdV[i][j]*=factor_dUdV;
+            }
+        }
+    }
+    else
+    {
+        std::cout<<"Not yet implemented"<<std::endl;
+        std::abort();
+    }
+
+
+    std::array<dealii::Tensor<1,dim,real>,nstate> out_vector;
+    for(unsigned int i=0; i<nstate; ++i)
+    {
+        for(unsigned int j=0; j<nstate; ++j)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                out_vector[i][d] += dUdV[i][j]*in_vector[j][d];
+            }
+        }
+    }
+    return out_vector;
+}
+
+template <int dim, int nstate, typename real>
+void NavierStokes<dim,nstate,real>
+::boundary_face_values_entropy_var(
+    const dealii::Point<dim,real> &pos,
+    const std::array<real,nstate> & v_int_at_q,
+    const std::array<dealii::Tensor<1,dim,real>,nstate> &poly_sigma_at_q,
+    const std::array<dealii::Tensor<1,dim,real>,nstate> &grad_entropy_var_int_at_q,
+    std::array<real,nstate> & v_bc_at_q,
+    std::array<dealii::Tensor<1,dim,real>,nstate> &sigma_bc_at_q,
+    const dealii::Tensor<1,dim,real> &unit_phys_normal,
+    const unsigned int boundary_id) const
+{
+    // Note: Computes v_bc as the actual entropy var at the boundary, without assuming averaging.
+    if(boundary_id==1001)//Adiabatic wall boundary zero velocity
+    {
+        for(unsigned int s=0; s<nstate-1; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                sigma_bc_at_q[s][d] = poly_sigma_at_q[s][d];
+            }
+        }
+
+
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            sigma_bc_at_q[nstate-1][d] = 0.0;
+        }
+
+
+        v_bc_at_q[0] = v_int_at_q[0];
+        for(unsigned int i=1; i<=dim; ++i)
+        {
+            v_bc_at_q[i] = 0.0;
+        }
+        v_bc_at_q[nstate-1] = v_int_at_q[nstate-1];
+    }
+    else if(boundary_id == 1010) // Moving adiabatic wall boundary
+    {
+        for(unsigned int s=0; s<nstate-1; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                sigma_bc_at_q[s][d] = poly_sigma_at_q[s][d];
+            }
+        }
+        std::array<real,dim> v_wall;
+        v_wall.fill(0.0);
+        v_wall[0] = 1.0;
+
+
+        for(unsigned int d=0; d<dim; ++d)
+        {
+            sigma_bc_at_q[nstate-1][d] = 0.0;
+            for(unsigned int d2 = 0; d2<dim; ++d2)
+            {
+                sigma_bc_at_q[nstate-1][d] += v_wall[d2]*poly_sigma_at_q[1+d2][d];
+            }
+        }
+
+        v_bc_at_q[0] = v_int_at_q[0];
+        for(unsigned int i=1; i<=dim; ++i)
+        {
+            v_bc_at_q[i] = -v_wall[i-1]*v_int_at_q[nstate-1];
+        }
+        v_bc_at_q[nstate-1] = v_int_at_q[nstate-1];
+    }
+    else
+    {
+        const std::array<real,nstate> soln_int = this->compute_conservative_variables_from_entropy_variables (v_int_at_q);
+        const std::array<dealii::Tensor<1,dim,real>,nstate> soln_grad_int = apply_d_conservative_var_d_entropy_var(grad_entropy_var_int_at_q, v_int_at_q);
+        /*
+        //=============================================================================
+        // Test flux
+        std::array<dealii::Tensor<1,dim,real>,nstate> expected_dissipative_flux = dissipative_flux(soln_int, soln_grad_int);
+        real errorval = 0.0;
+        sigma_bc_at_q = dissipative_flux_entropy_based (v_int_at_q, grad_entropy_var_int_at_q);
+        for(unsigned int s=0; s<nstate; ++s)
+        {
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                errorval += pow((sigma_bc_at_q[s][d] - (-expected_dissipative_flux[s][d])),2);
+            }
+        }
+        errorval = sqrt(errorval);
+        if(errorval > 1.0e-10)
+        {
+            std::cout<<"High errorval = "<<errorval<<" . Aborting.."<<std::endl;
+            std::abort();
+        }
+        //==============================================================================
+        */
+        std::array<real,nstate> soln_bc;
+        std::array<dealii::Tensor<1,dim,real>,nstate> soln_grad_bc;
+        this->boundary_face_values (
+           boundary_id,
+           pos,
+           unit_phys_normal,
+           soln_int,
+           soln_grad_int,
+           soln_bc,
+           soln_grad_bc);
+
+        v_bc_at_q = this->compute_entropy_variables(soln_bc);
+        std::array<dealii::Tensor<1,dim,real>,nstate> grad_entropyvar_bc = apply_d_entropy_var_d_conservative_var(soln_grad_bc,v_bc_at_q);
+        sigma_bc_at_q = dissipative_flux_entropy_based (v_bc_at_q, grad_entropyvar_bc);
+    }
+}
+
 template <int dim, int nspecies, int nstate, typename real>
 dealii::Tensor<1,dim,real> NavierStokes<dim,nspecies,nstate,real>
 ::compute_scaled_viscosity_gradient (

--- a/src/physics/navier_stokes.cpp
+++ b/src/physics/navier_stokes.cpp
@@ -1362,7 +1362,7 @@ void NavierStokes<dim,nspecies,nstate,real>
     const dealii::Tensor<1,dim,real> &unit_phys_normal,
     const unsigned int boundary_id) const
 {
-    // Note: Computes v_bc as the actual entropy var at the boundary, without assuming averaging.
+    // Note: Computes v_bc as the actual entropy var at the boundary.
     if(boundary_id==1001)//Adiabatic wall boundary zero velocity
     {
         for(unsigned int s=0; s<nstate-1; ++s)

--- a/src/physics/navier_stokes.h
+++ b/src/physics/navier_stokes.h
@@ -402,6 +402,35 @@ public:
     dissipative_flux (
         const std::array<real,nstate> &conservative_soln,
         const std::array<dealii::Tensor<1,dim,real>,nstate> &solution_gradient) const override;
+    
+    /// Dissipative flux based on entropy variables
+    std::array<dealii::Tensor<1,dim,real>,nstate>
+    dissipative_flux_entropy_based (
+        const std::array<real,nstate> &entropy_var,
+        const std::array<dealii::Tensor<1,dim,real>,nstate> &entropy_var_gradient) const override;
+
+    /// Viscous BCs based on entropy variables
+    void boundary_face_values_entropy_var(
+        const dealii::Point<dim,real> &pos,
+        const std::array<real,nstate> & v_int_at_q,
+        const std::array<dealii::Tensor<1,dim,real>,nstate> &poly_sigma_at_q,
+        const std::array<dealii::Tensor<1,dim,real>,nstate> &grad_entropy_var_int_at_q,
+        std::array<real,nstate> & v_bc_at_q,
+        std::array<dealii::Tensor<1,dim,real>,nstate> &sigma_bc_at_q,
+        const dealii::Tensor<1,dim,real> &unit_phys_normal,
+        const unsigned int boundary_id) const override;
+
+    /// Computes dU/dV * input, where U is conservative and V is the entropy variable
+    std::array<dealii::Tensor<1,dim,real>,nstate>
+    apply_d_conservative_var_d_entropy_var(
+        const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
+        const std::array<real,nstate> & entropy_var) const;
+
+    /// Computes dV/dU * input, where U is conservative and V is the entropy variable
+    std::array<dealii::Tensor<1,dim,real>,nstate>
+    apply_d_entropy_var_d_conservative_var(
+        const std::array<dealii::Tensor<1,dim,real>,nstate> & in_vector,
+        const std::array<real,nstate> & entropy_var) const;
 
     /** Gradient of the scaled nondimensionalized viscosity coefficient
      *  Reference: Masatsuka 2018 "I do like CFD", p.148, eq.(4.14.14 and 4.14.17)

--- a/src/physics/physics.h
+++ b/src/physics/physics.h
@@ -165,6 +165,32 @@ public:
         const std::array<dealii::Tensor<1,dim,real>,nstate> &solution_gradient,
         const dealii::types::global_dof_index cell_index) const = 0;
 
+    /// Dissipative flux based on the entropy variables
+    virtual std::array<dealii::Tensor<1,dim,real>,nstate>
+    dissipative_flux_entropy_based (
+    const std::array<real,nstate> &/*entropy_var*/,
+    const std::array<dealii::Tensor<1,dim,real>,nstate> &/*entropy_var_gradient*/) const
+    {
+        std::cout<<"Not implemented for this PDE. Aborting.."<<std::endl;
+        std::abort();
+    }
+
+    /// BCs to ensure entropy stability at the boundary
+    virtual void boundary_face_values_entropy_var(
+        const dealii::Point<dim,real> &/*pos*/,
+        const std::array<real,nstate> & /*v_int_at_q*/, 
+        const std::array<dealii::Tensor<1,dim,real>,nstate> &/*poly_sigma_at_q*/, 
+        const std::array<dealii::Tensor<1,dim,real>,nstate> &/*grad_entropy_var_int_at_q*/, 
+        std::array<real,nstate> & /*v_bc_at_q*/, 
+        std::array<dealii::Tensor<1,dim,real>,nstate> &/*sigma_bc_at_q*/, 
+        const dealii::Tensor<1,dim,real> &/*unit_phys_normal*/,
+        const unsigned int /*boundary_id*/) const
+    {
+        // Does nothing.
+        std::cout<<"Not implemented for this PDE. Aborting.."<<std::endl;
+        std::abort();
+    }
+
     /// Artificial dissipative fluxes that will be differentiated ONCE in space.
     /** Stems from the Persson2006 paper on subcell shock capturing */
 /*    virtual std::array<dealii::Tensor<1,dim,real>,nstate> artificial_dissipative_flux (

--- a/src/testing/CMakeLists.txt
+++ b/src/testing/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TESTS_SOURCE
     turbulent_channel_flow_skin_friction_check.cpp
     dipole_wall_collision_unsteady_quantity_check.cpp
     turbulent_channel_flow_unsteady_quantity_check.cpp
+    lid_driven_cavity.cpp
     )
 
 foreach(dim RANGE 1 3)

--- a/src/testing/lid_driven_cavity.cpp
+++ b/src/testing/lid_driven_cavity.cpp
@@ -1,0 +1,185 @@
+#include <stdlib.h>
+#include <iostream>
+#include <deal.II/grid/grid_refinement.h>
+#include "physics/manufactured_solution.h"
+#include "lid_driven_cavity.hpp"
+#include "flow_solver/flow_solver_factory.h"
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+namespace PHiLiP {
+namespace Tests {
+
+template <int dim, int nspecies, int nstate>
+LidDrivenCavity<dim,nspecies,nstate>::LidDrivenCavity(const Parameters::AllParameters *const parameters_input,
+                                                      const dealii::ParameterHandler &parameter_handler_input)
+    :
+    TestsBase::TestsBase(parameters_input)
+    , parameter_handler(parameter_handler_input)
+{}
+
+template<int dim, int nspecies, int nstate>
+int LidDrivenCavity<dim,nspecies,nstate>
+::run_test () const
+{
+    Parameters::AllParameters param = *(TestsBase::all_parameters);
+    // Create grid
+    dealii::Point<dim> p1;
+    dealii::Point<dim> p2;
+    for(unsigned int d=0; d<dim; ++d)
+    {
+        p1[d] = -1.0;
+        p2[d] = 1.0;
+    }
+    std::shared_ptr<Triangulation> grid = std::make_shared<Triangulation>(
+        #if PHILIP_DIM!=1
+        this->mpi_communicator
+        #endif
+    );
+    
+    dealii::GridGenerator::hyper_rectangle	( *grid, p1, p2,true );
+    for (typename dealii::parallel::distributed::Triangulation<dim>::active_cell_iterator cell = grid->begin_active(); cell != grid->end(); ++cell) {
+        for (unsigned int face=0; face<dealii::GeometryInfo<dim>::faces_per_cell; ++face) {
+            if (cell->face(face)->at_boundary()) {
+                unsigned int current_id = cell->face(face)->boundary_id();
+                if (current_id == 3 ) {cell->face(face)->set_boundary_id (1010);} // top
+                else {cell->face(face)->set_boundary_id (1001);}
+            }
+        }
+    }
+    grid->refine_global(param.flow_solver_param.number_of_mesh_refinements);
+    // Create flow solver
+    std::unique_ptr<FlowSolver::FlowSolver<dim,nspecies,nstate>> flow_solver = FlowSolver::FlowSolverFactory<dim,nspecies,nstate>::select_flow_case(&param, parameter_handler);
+    std::shared_ptr<HighOrderGrid<dim,double>> cube_grid = std::make_shared<HighOrderGrid<dim,double>>(1,grid,true,true,false);
+    flow_solver->dg->set_high_order_grid(cube_grid);
+    flow_solver->dg->allocate_system(false,false,false);
+    // Initialize solution
+    Physics::Euler<dim,nspecies,nstate,double> euler_physics_double = Physics::Euler<dim, nspecies, nstate, double>(
+            &param,
+            param.euler_param.ref_length,
+            param.euler_param.gamma_gas,
+            param.euler_param.mach_inf,
+            param.euler_param.angle_of_attack,
+            param.euler_param.side_slip_angle);
+    auto initial_condition_function = std::make_shared<InitialConditionLidDrivenCavity<dim,nspecies,nstate>>(euler_physics_double);
+    SetInitialCondition<dim,nspecies,nstate,double>::set_initial_condition(initial_condition_function, flow_solver->dg, &param);
+    flow_solver->dg->solution.update_ghost_values();
+    
+    // Test entropy stability
+    const double finalTime = param.flow_solver_param.final_time;
+
+    pcout << " number dofs " << flow_solver->dg->dof_handler.n_dofs()<<std::endl;
+    pcout << "preparing to advance solution in time" << std::endl;
+
+    flow_solver->ode_solver->current_iteration = 0;
+    flow_solver->ode_solver->allocate_ode_system();
+
+    //loop over time
+    while(flow_solver->ode_solver->current_time < finalTime){
+        //get timestep
+        const double time_step =  param.flow_solver_param.constant_time_step;
+        if(flow_solver->ode_solver->current_iteration%param.ode_solver_param.print_iteration_modulo==0)
+            pcout<<"time step "<<time_step<<" current time "<<flow_solver->ode_solver->current_time<<std::endl;
+        //take the minimum timestep from all processors.
+        const double dt = time_step;
+        //integrate in time
+        flow_solver->ode_solver->step_in_time(dt, false);
+        flow_solver->ode_solver->current_iteration += 1;
+
+        //get the change in entropy
+        const double current_change_entropy = compute_change_in_entropy(flow_solver->dg, param.flow_solver_param.poly_degree);
+        pcout << "Change in Entropy at time " << flow_solver->ode_solver->current_time << " is " << current_change_entropy<< std::endl;
+        //check if change in entropy is non-positive
+        if(current_change_entropy > 1e-12){
+          pcout << " Change in entropy should be negative. Test failed..." << std::endl;
+          return 1;
+        }
+    }
+    return 0;
+}
+template<int dim, int nspecies, int nstate>
+double LidDrivenCavity<dim,nspecies, nstate>::compute_change_in_entropy(const std::shared_ptr < DGBase<dim,nspecies, double> > &dg, unsigned int poly_degree) const
+{
+    const unsigned int n_dofs_cell = dg->fe_collection[poly_degree].dofs_per_cell;
+    const unsigned int n_quad_pts = dg->volume_quadrature_collection[poly_degree].size();
+    const unsigned int n_shape_fns = n_dofs_cell / nstate;
+    //We have to project the vector of entropy variables because the mass matrix has an interpolation from solution nodes built into it.
+    OPERATOR::vol_projection_operator<dim,2*dim> vol_projection(1, poly_degree, dg->max_grid_degree);
+    vol_projection.build_1D_volume_operator(dg->oneD_fe_collection_1state[poly_degree], dg->oneD_quadrature_collection[poly_degree]);
+
+
+    OPERATOR::basis_functions<dim,2*dim> soln_basis(1, poly_degree, dg->max_grid_degree);
+    soln_basis.build_1D_volume_operator(dg->oneD_fe_collection_1state[poly_degree], dg->oneD_quadrature_collection[poly_degree]);
+
+
+    dealii::LinearAlgebra::distributed::Vector<double> entropy_var_hat_global(dg->right_hand_side);
+    std::vector<dealii::types::global_dof_index> dofs_indices (n_dofs_cell);
+
+    std::shared_ptr < Physics::Euler<dim,nspecies, nstate, double > > euler_double  = std::dynamic_pointer_cast<Physics::Euler<dim,nspecies,dim+2,double>>(PHiLiP::Physics::PhysicsFactory<dim,nspecies,nstate,double>::create_Physics(dg->all_parameters));
+
+    for (auto cell = dg->dof_handler.begin_active(); cell!=dg->dof_handler.end(); ++cell) {
+        if (!cell->is_locally_owned()) continue;
+        cell->get_dof_indices (dofs_indices);
+
+        //get solution modal coeff
+        std::array<std::vector<double>,nstate> soln_coeff;
+        for(unsigned int idof=0; idof<n_dofs_cell; idof++){
+            const unsigned int istate = dg->fe_collection[poly_degree].system_to_component_index(idof).first;
+            const unsigned int ishape = dg->fe_collection[poly_degree].system_to_component_index(idof).second;
+            if(ishape == 0)
+                soln_coeff[istate].resize(n_shape_fns);
+            soln_coeff[istate][ishape] = dg->solution(dofs_indices[idof]);
+        }
+
+        //interpolate solution to quadrature points
+        std::array<std::vector<double>,nstate> soln_at_q;
+        for(int istate=0; istate<nstate; istate++){
+            soln_at_q[istate].resize(n_quad_pts);
+            soln_basis.matrix_vector_mult_1D(soln_coeff[istate], soln_at_q[istate],
+                                             soln_basis.oneD_vol_operator);
+        }
+        //compute entropy and kinetic energy "entropy" variables at quad points
+        std::array<std::vector<double>,nstate> entropy_var_at_q;
+        for(unsigned int iquad=0; iquad<n_quad_pts; iquad++){
+            std::array<double,nstate> soln_state;
+            for(int istate=0; istate<nstate; istate++){
+                soln_state[istate] = soln_at_q[istate][iquad];
+            }
+            std::array<double,nstate> entropy_var_state = euler_double->compute_entropy_variables(soln_state);
+            for(int istate=0; istate<nstate; istate++){
+                if(iquad==0){
+                    entropy_var_at_q[istate].resize(n_quad_pts);
+                }
+                entropy_var_at_q[istate][iquad] = entropy_var_state[istate];
+            }
+        }
+        //project the enrtopy and KE var to modal coefficients
+        //then write it into a global vector
+        for(int istate=0; istate<nstate; istate++){
+            //Projected vector of entropy variables.
+            std::vector<double> entropy_var_hat(n_shape_fns);
+            vol_projection.matrix_vector_mult_1D(entropy_var_at_q[istate], entropy_var_hat,
+                                                 vol_projection.oneD_vol_operator);
+
+            for(unsigned int ishape=0; ishape<n_shape_fns; ishape++){
+                const unsigned int idof = istate * n_shape_fns + ishape;
+                entropy_var_hat_global[dofs_indices[idof]] = entropy_var_hat[ishape];
+            }
+        }
+    }
+    entropy_var_hat_global.update_ghost_values();;
+
+    //evaluate the change in entropy and change in KE
+    dg->assemble_residual();
+    return entropy_var_hat_global * dg->right_hand_side;
+}
+
+
+#if PHILIP_DIM>=2 && PHILIP_SPECIES==1
+    template class LidDrivenCavity <PHILIP_DIM, PHILIP_SPECIES,PHILIP_DIM+2>;
+#endif
+
+} // Tests namespace
+} // PHiLiP namespace
+
+

--- a/src/testing/lid_driven_cavity.hpp
+++ b/src/testing/lid_driven_cavity.hpp
@@ -1,0 +1,99 @@
+#ifndef __LID_DRIVEN_CAVITY_H__
+#define __LID_DRIVEN_CAVITY_H__ 
+
+#include <deal.II/grid/manifold_lib.h>
+
+#include "dg/dg_base.hpp"
+#include "parameters/all_parameters.h"
+#include "physics/physics.h"
+#include "physics/initial_conditions/set_initial_condition.h"
+#include "tests.h"
+#include <deal.II/base/function.h>
+
+namespace PHiLiP {
+namespace Tests {
+
+/// Tests entropy stability for lid driven cavity with moving and static wall BCs.
+template <int dim, int nspecies, int nstate>
+class LidDrivenCavity: public TestsBase
+{
+#if PHILIP_DIM==1
+    using Triangulation = dealii::Triangulation<PHILIP_DIM>;
+#else
+    using Triangulation = dealii::parallel::distributed::Triangulation<PHILIP_DIM>;
+#endif
+public:
+    /// Constructor. Deleted the default constructor since it should not be used
+    LidDrivenCavity () = delete;
+    /// Constructor.
+    /** Simply calls the TestsBase constructor to set its parameters = parameters_input
+     */
+    LidDrivenCavity(const Parameters::AllParameters *const parameters_input,
+                    const dealii::ParameterHandler &parameter_handler_input);
+
+
+    /// Parameter handler for storing the .prm file being ran
+    const dealii::ParameterHandler &parameter_handler;
+
+    /// Tests entropy stability
+    int run_test () const;
+
+    /// Computes change in entropy i.e. entropy_variable * right_hand_side.
+    double compute_change_in_entropy(const std::shared_ptr < DGBase<dim, nspecies, double> > &dg, unsigned int poly_degree) const;
+};
+
+/// Function used to evaluate initial conservative solution
+template <int dim, int nspecies, int nstate>
+class InitialConditionLidDrivenCavity: public InitialConditionFunction<dim,nspecies,nstate,double>
+{
+protected:
+    using dealii::Function<dim,double>::value; ///< dealii::Function we are templating on
+
+public:
+    /// Farfield conservative solution
+    std::array<double,nstate> farfield_conservative;
+
+    /// Constructor.
+    /** Evaluates the primary farfield solution and converts it into the store farfield_conservative solution
+     */
+    explicit InitialConditionLidDrivenCavity (const Physics::Euler<dim,nspecies,nstate,double> euler_physics)
+            : InitialConditionFunction<dim,nspecies,nstate,double>()
+    {
+        const double density_bc = euler_physics.density_inf;
+        const double pressure_bc = 1.0/(euler_physics.gam*euler_physics.mach_inf_sqr);
+        std::array<double,nstate> primitive_boundary_values;
+        primitive_boundary_values[0] = density_bc;
+        for (int d=0;d<dim;d++) { primitive_boundary_values[1+d] = euler_physics.velocities_inf[d]; }
+        primitive_boundary_values[nstate-1] = pressure_bc;
+        farfield_conservative = euler_physics.convert_primitive_to_conservative(primitive_boundary_values);
+    }
+
+    /// Returns the value
+    double value (const dealii::Point<dim> &/*point*/, const unsigned int istate) const override
+    {
+        if(istate==0)
+        {
+            return 1.0;
+        }
+        else if(istate==(nstate-1))
+        {
+            double sum=0.0;
+            for(unsigned int d=0; d<dim; ++d)
+            {
+                sum += 0.5*pow(farfield_conservative[1+d],2)/farfield_conservative[0];
+            }
+            const double pressure = (farfield_conservative[nstate-1] - sum)*0.4;
+           
+           return pressure/0.4;
+        }
+        else
+        {
+            return 0.0;
+        }
+    }
+};
+} // Tests namespace
+} // PHiLiP namespace
+#endif
+
+

--- a/src/testing/lid_driven_cavity.hpp
+++ b/src/testing/lid_driven_cavity.hpp
@@ -42,7 +42,7 @@ public:
     double compute_change_in_entropy(const std::shared_ptr < DGBase<dim, nspecies, double> > &dg, unsigned int poly_degree) const;
 };
 
-/// Function used to evaluate initial conservative solution
+/// Function used to evaluate initial conservative solution. Using the same initial condition and the test case as in Chan, Jesse, Yimin Lin, and Tim Warburton. "Entropy stable modal discontinuous Galerkin schemes and wall boundary conditions for the compressible Navier-Stokes equations." Journal of Computational Physics 448 (2022).
 template <int dim, int nspecies, int nstate>
 class InitialConditionLidDrivenCavity: public InitialConditionFunction<dim,nspecies,nstate,double>
 {

--- a/src/testing/tests.cpp
+++ b/src/testing/tests.cpp
@@ -59,6 +59,7 @@
 #include "hyper_adaptive_sampling_new_error.h"
 #include "halton_sampling_run.h"
 #include "multispecies_vortex_advection.h"
+#include "lid_driven_cavity.hpp"
 
 namespace PHiLiP {
 namespace Tests {
@@ -304,6 +305,8 @@ std::unique_ptr< TestsBase > TestsFactory<dim,nspecies,nstate,MeshType>
         if constexpr (((dim==2 && nstate==dim+2) || (dim==1 && nstate==1)) && nspecies==1) return std::make_unique<AdaptiveSamplingTesting<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::euler_naca0012) {
         if constexpr (dim==2 && nstate==dim+2 && nspecies==1) return std::make_unique<EulerNACA0012<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
+    } else if(test_type == Test_enum::lid_driven_cavity) {
+        if constexpr (dim==2 && nstate==dim+2 && nspecies==1) return std::make_unique<LidDrivenCavity<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::dual_weighted_residual_mesh_adaptation) {
         if constexpr (dim==2 && nstate==1 && nspecies==1)  return std::make_unique<DualWeightedResidualMeshAdaptation<dim, nspecies, nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::anisotropic_mesh_adaptation) {

--- a/src/testing/tests.cpp
+++ b/src/testing/tests.cpp
@@ -306,7 +306,7 @@ std::unique_ptr< TestsBase > TestsFactory<dim,nspecies,nstate,MeshType>
     } else if(test_type == Test_enum::euler_naca0012) {
         if constexpr (dim==2 && nstate==dim+2 && nspecies==1) return std::make_unique<EulerNACA0012<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::lid_driven_cavity) {
-        if constexpr (dim==2 && nstate==dim+2 && nspecies==1) return std::make_unique<LidDrivenCavity<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
+        if constexpr (dim>=2 && nstate==dim+2 && nspecies==1) return std::make_unique<LidDrivenCavity<dim,nspecies,nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::dual_weighted_residual_mesh_adaptation) {
         if constexpr (dim==2 && nstate==1 && nspecies==1)  return std::make_unique<DualWeightedResidualMeshAdaptation<dim, nspecies, nstate>>(parameters_input,parameter_handler_input);
     } else if(test_type == Test_enum::anisotropic_mesh_adaptation) {

--- a/tests/integration_tests_control_files/euler_integration/2d_lid_driven_cavity.prm
+++ b/tests/integration_tests_control_files/euler_integration/2d_lid_driven_cavity.prm
@@ -1,0 +1,53 @@
+# Listing of Parameters
+# ---------------------
+
+set test_type = lid_driven_cavity
+
+# Number of dimensions
+set dimension = 2
+
+# The PDE we want to solve. Choices are
+# <advection|diffusion|convection_diffusion>.
+set pde_type  = navier_stokes
+set use_weak_form = false
+set conv_num_flux = two_point_flux
+set two_point_num_flux_type = CH
+
+set use_split_form = true
+set use_curvilinear_split_form = true
+set use_viscous_br2_entropystable = true
+set use_projected_entropy_variables_for_nsfr_boundary_term = true
+
+#set output_face_results_vtk = true
+
+subsection euler
+  set reference_length = 1.0
+  set mach_infinity = 0.10
+end
+
+subsection navier_stokes
+  set reynolds_number_inf = 1000.0
+end
+
+
+subsection ODE solver
+  #set output_solution_every_x_steps = 1
+  set ode_solver_type = runge_kutta
+  set runge_kutta_method = rk4_ex
+end
+
+
+subsection flow_solver
+  set flow_case_type = isentropic_vortex
+  #set steady_state_polynomial_ramping = true
+  set poly_degree = 3
+  set constant_time_step = 1.0e-3
+  set final_time = 100
+  set steady_state = false
+  subsection grid
+    #set input_mesh_filename = ../../meshes/naca0012_hopw_ref0
+    set number_of_mesh_refinements = 4
+    set grid_degree = 1
+  end
+end
+

--- a/tests/integration_tests_control_files/euler_integration/3d_lid_driven_cavity.prm
+++ b/tests/integration_tests_control_files/euler_integration/3d_lid_driven_cavity.prm
@@ -1,0 +1,51 @@
+# Listing of Parameters
+# ---------------------
+
+set test_type = lid_driven_cavity
+
+# Number of dimensions
+set dimension = 3
+
+# The PDE we want to solve. Choices are
+# <advection|diffusion|convection_diffusion>.
+set pde_type  = navier_stokes
+set use_weak_form = false
+set conv_num_flux = two_point_flux
+set two_point_num_flux_type = CH
+
+set use_split_form = true
+set use_curvilinear_split_form = true
+set use_viscous_br2_entropystable = true
+set use_projected_entropy_variables_for_nsfr_boundary_term = true
+
+#set output_face_results_vtk = true
+
+subsection euler
+  set reference_length = 1.0
+  set mach_infinity = 0.10
+end
+
+subsection navier_stokes
+  set reynolds_number_inf = 1000.0
+end
+
+
+subsection ODE solver
+  #set output_solution_every_x_steps = 1
+  set ode_solver_type = runge_kutta
+  set runge_kutta_method = rk4_ex
+end
+
+
+subsection flow_solver
+  set flow_case_type = isentropic_vortex
+  set poly_degree = 2
+  set constant_time_step = 1.0e-3
+  set final_time = 100.0
+  set steady_state = false
+  subsection grid
+    set number_of_mesh_refinements = 2
+    set grid_degree = 1
+  end
+end
+

--- a/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
@@ -459,6 +459,34 @@ set_tests_labels(MPI_2D_EULER_INTEGRATION_CYLINDER_ADJOINT_LONG EULER_INTEGRATIO
                                                                 MODERATE
                                                                 INTEGRATION_TEST)
 
+configure_file(2d_lid_driven_cavity.prm 2d_lid_driven_cavity.prm COPYONLY)
+add_test(
+  NAME 2D_LID_DRIVEN_CAVITY
+  COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_lid_driven_cavity.prm
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+set_tests_labels(2D_LID_DRIVEN_CAVITY                           EULER_INTEGRATION
+                                                                2D
+                                                                PARALLEL
+                                                                NAVIER_STOKES
+                                                                STRONG
+                                                                UNCOLLOCATED
+                                                                INTEGRATION_TEST)
+
+configure_file(3d_lid_driven_cavity.prm 3d_lid_driven_cavity.prm COPYONLY)
+add_test(
+  NAME 3D_LID_DRIVEN_CAVITY
+  COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_lid_driven_cavity.prm
+  WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
+)
+set_tests_labels(3D_LID_DRIVEN_CAVITY                           EULER_INTEGRATION
+                                                                3D
+                                                                PARALLEL
+                                                                NAVIER_STOKES
+                                                                STRONG
+                                                                UNCOLLOCATED
+                                                                INTEGRATION_TEST)
+
 # Vortex test case takes wayyy too much time. It works, so uncomment below if you want to wait.
 # configure_file(2d_euler_vortex.prm 2d_euler_vortex.prm COPYONLY)
 # add_test(

--- a/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
+++ b/tests/integration_tests_control_files/euler_integration/CMakeLists.txt
@@ -461,11 +461,11 @@ set_tests_labels(MPI_2D_EULER_INTEGRATION_CYLINDER_ADJOINT_LONG EULER_INTEGRATIO
 
 configure_file(2d_lid_driven_cavity.prm 2d_lid_driven_cavity.prm COPYONLY)
 add_test(
-  NAME 2D_LID_DRIVEN_CAVITY
+  NAME 2D_LID_DRIVEN_CAVITY_ENTROPY_STABILITY
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_2D -i ${CMAKE_CURRENT_BINARY_DIR}/2d_lid_driven_cavity.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(2D_LID_DRIVEN_CAVITY                           EULER_INTEGRATION
+set_tests_labels(2D_LID_DRIVEN_CAVITY_ENTROPY_STABILITY         EULER_INTEGRATION
                                                                 2D
                                                                 PARALLEL
                                                                 NAVIER_STOKES
@@ -475,11 +475,11 @@ set_tests_labels(2D_LID_DRIVEN_CAVITY                           EULER_INTEGRATIO
 
 configure_file(3d_lid_driven_cavity.prm 3d_lid_driven_cavity.prm COPYONLY)
 add_test(
-  NAME 3D_LID_DRIVEN_CAVITY
+  NAME 3D_LID_DRIVEN_CAVITY_ENTROPY_STABILITY
   COMMAND mpirun -np ${MPIMAX} ${EXECUTABLE_OUTPUT_PATH}/PHiLiP_3D -i ${CMAKE_CURRENT_BINARY_DIR}/3d_lid_driven_cavity.prm
   WORKING_DIRECTORY ${TEST_OUTPUT_DIR}
 )
-set_tests_labels(3D_LID_DRIVEN_CAVITY                           EULER_INTEGRATION
+set_tests_labels(3D_LID_DRIVEN_CAVITY_ENTROPY_STABILITY         EULER_INTEGRATION
                                                                 3D
                                                                 PARALLEL
                                                                 NAVIER_STOKES

--- a/tests/unit_tests/sensitivities/dRdW_fd_vs_ad_strong.cpp
+++ b/tests/unit_tests/sensitivities/dRdW_fd_vs_ad_strong.cpp
@@ -181,27 +181,34 @@ int main (int argc, char * argv[])
     Parameters::AllParameters all_parameters;
     all_parameters.parse_parameters (parameter_handler);
     all_parameters.use_weak_form = false;
+    all_parameters.use_split_form = true;
+    all_parameters.use_curvilinear_split_form = true;
+    all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::two_point_flux;
     std::vector<PDEType> pde_type {
     //    PDEType::diffusion
          PDEType::advection
         // , PDEType::convection_diffusion
         , PDEType::advection_vector
         , PDEType::euler
-    //    , PDEType::navier_stokes
+#if PHILIP_DIM>=2
+        , PDEType::navier_stokes
+#endif
 //#if PHILIP_DIM==3
 //        , PDEType::physics_model
 //#endif
     };
     std::vector<std::string> pde_name {
-         " PDEType::diffusion "
-        , " PDEType::advection "
+        // " PDEType::diffusion "
+          " PDEType::advection "
         // , " PDEType::convection_diffusion "
         , " PDEType::advection_vector "
         , " PDEType::euler "
+#if PHILIP_DIM>=2
         , " PDEType::navier_stokes "
-#if PHILIP_DIM==3
-        , " PDEType::physics_model "
 #endif
+//#if PHILIP_DIM==3
+//        , " PDEType::physics_model "
+//#endif
     };
 #if PHILIP_DIM==3
     ModelType model = ModelType::large_eddy_simulation
@@ -212,9 +219,9 @@ int main (int argc, char * argv[])
         ipde++;
         for (unsigned int poly_degree=1; poly_degree<3; ++poly_degree) {
             for (unsigned int igrid=2; igrid<4; ++igrid) {
+                pcout<<"\n";
                 pcout << "Using " << pde_name[ipde] << std::endl;
                 all_parameters.pde_type = *pde;
-                all_parameters.diss_num_flux_type = Parameters::AllParameters::DissipativeNumericalFlux::bassi_rebay_2;
                 // Generate grids
                 std::shared_ptr<Triangulation> grid = std::make_shared<Triangulation>(
 #if PHILIP_DIM!=1
@@ -240,6 +247,15 @@ int main (int argc, char * argv[])
          || ((*pde==PDEType::physics_model) && (model==ModelType::large_eddy_simulation))
 #endif
                     ) {
+                    //all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::l2roe;
+                    //all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::KG;
+                    //all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::IR;
+                    all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::CH;
+                    if(*pde==PDEType::navier_stokes)
+                    {
+                        all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::two_point_flux_with_roe_dissipation;
+                        all_parameters.use_viscous_br2_entropystable = true;
+                    }
                     error = test<dim,nspecies,dim+2>(poly_degree, grid, all_parameters);
                 } else if (*pde==PDEType::burgers_inviscid) {
                     error = test<dim,nspecies,dim>(poly_degree, grid, all_parameters);

--- a/tests/unit_tests/sensitivities/dRdW_fd_vs_ad_strong.cpp
+++ b/tests/unit_tests/sensitivities/dRdW_fd_vs_ad_strong.cpp
@@ -184,6 +184,7 @@ int main (int argc, char * argv[])
     all_parameters.use_split_form = true;
     all_parameters.use_curvilinear_split_form = true;
     all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::two_point_flux;
+    all_parameters.use_projected_entropy_variables_for_nsfr_boundary_term = true;
     std::vector<PDEType> pde_type {
     //    PDEType::diffusion
          PDEType::advection

--- a/tests/unit_tests/sensitivities/dRdX_fd_vs_ad_strong.cpp
+++ b/tests/unit_tests/sensitivities/dRdX_fd_vs_ad_strong.cpp
@@ -210,13 +210,19 @@ int main (int argc, char * argv[])
     Parameters::AllParameters all_parameters;
     all_parameters.parse_parameters (parameter_handler);
     all_parameters.use_weak_form = false;
+    all_parameters.use_split_form = true;
+    all_parameters.use_curvilinear_split_form = true;
+    all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::two_point_flux;
+    all_parameters.use_projected_entropy_variables_for_nsfr_boundary_term = true;
     std::vector<PDEType> pde_type {
         //PDEType::diffusion
          PDEType::advection
         // , PDEType::convection_diffusion
         , PDEType::advection_vector
         , PDEType::euler
-       // , PDEType::navier_stokes
+        #if PHILIP_DIM>=2
+        , PDEType::navier_stokes
+        #endif
 //#if PHILIP_DIM==3
 //        , PDEType::physics_model
 //#endif
@@ -227,7 +233,9 @@ int main (int argc, char * argv[])
         // , " PDEType::convection_diffusion "
         , " PDEType::advection_vector "
         , " PDEType::euler "
-      //  , " PDEType::navier_stokes "
+        #if PHILIP_DIM>=2
+        , " PDEType::navier_stokes "
+        #endif
 //#if PHILIP_DIM==3
 //        , " PDEType::physics_model "
 //#endif
@@ -241,7 +249,7 @@ int main (int argc, char * argv[])
         ipde++;
         for (unsigned int poly_degree=1; poly_degree<3; ++poly_degree) {
             for (unsigned int igrid=2; igrid<4; ++igrid) {
-                pcout << "Using " << pde_name[ipde] << std::endl;
+                pcout << "\nUsing " << pde_name[ipde] << std::endl;
                 all_parameters.pde_type = *pde;
                 // Generate grids
                 std::shared_ptr<Triangulation> grid = std::make_shared<Triangulation>(
@@ -268,6 +276,15 @@ int main (int argc, char * argv[])
          || ((*pde==PDEType::physics_model) && (model==ModelType::large_eddy_simulation))
 #endif
                     ) {
+                    //all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::l2roe;
+                    //all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::KG;
+                    //all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::IR;
+                    all_parameters.two_point_num_flux_type = Parameters::AllParameters::TwoPointNumericalFlux::CH;
+                    if(*pde==PDEType::navier_stokes)
+                    {
+                        all_parameters.conv_num_flux_type = Parameters::AllParameters::ConvectiveNumericalFlux::two_point_flux_with_roe_dissipation;
+                        all_parameters.use_viscous_br2_entropystable = true;
+                    }
                     error = test<dim,nspecies,dim+2>(poly_degree, grid, all_parameters);
                 } else if (*pde==PDEType::burgers_inviscid) {
                     error = test<dim,nspecies,dim>(poly_degree, grid, all_parameters);


### PR DESCRIPTION
This PR implements the entropy-stable viscous BR2 without an auxiliary equation. The NSFR viscous residual can now be automatically differentiated with this formulation.

Other changes: 
Moved viscous terms and the filtered solution's computation to separate functions. 